### PR TITLE
Removed hard coded value of registry host ip from action image in setup.

### DIFF
--- a/content/setup/action_images.md
+++ b/content/setup/action_images.md
@@ -10,8 +10,8 @@ toc = true
 
 ```sh
 docker pull quay.io/tinkerbell/tink-worker:latest
-docker tag quay.io/tinkerbell/tink-worker:latest 192.168.1.1/tink-worker
-docker push 192.168.1.1/tink-worker
+docker tag quay.io/tinkerbell/tink-worker:latest <registry-host>/tink-worker
+docker push <registry-host>/tink-worker
 ```
 
 - The registry must have an image for all the actions in a workflow.
@@ -24,6 +24,6 @@ docker push <registry-host>/<action-image>
 - For this demo, we are going to need an action image for displaying hello-world.
 ```sh
 docker pull hello-world
-docker tag hello-world 192.168.1.1/hello-world
-docker push 192.168.1.1/hello-world
+docker tag hello-world <registry-host>/hello-world
+docker push <registry-host>/hello-world
 ```


### PR DESCRIPTION
There were few places where hard coded value `192.168.1.1` of registry host ip in the action image page of setup was present. These values are replaced with the string `<registry-host>`.