### PR TITLE
Sanitizing hardwares entry when creating a workflow

### DIFF
--- a/content/cli-reference/workflow.md
+++ b/content/cli-reference/workflow.md
@@ -34,3 +34,6 @@ Workflow operations:
   $ tink workflow create -t <template-uuid> -r <targeted_hardware_devices_in_json_format>
   $ tink workflow create -t edb80a56-b1f2-4502-abf9-17326324192b -r '{"device_1":"mac/IP", "device_2":"mac/IP"}'
  ```
+ {{% notice note %}} 
+  The key used in the above command which is *device_1* should be in sync with *worker* field in the *template* and can only contain *letters*, *numbers* and *underscores*. Click [here](/concepts/) to check the template structure.
+ {{% /notice %}}

--- a/content/concepts/_index.md
+++ b/content/concepts/_index.md
@@ -73,6 +73,10 @@ A hardware device can be accessed in template like (refer above template):
 {{.device_2}}
 ```
 
+ {{% notice note %}}
+  These keys can only contain *letters*, *numbers* and *underscores*.
+ {{% /notice %}}
+
 ### Provisioner
 
 The provisioner machine is the main driver for executing a workflow.


### PR DESCRIPTION
In this commit a "Note" has been in place with template and workflow which defines what you can provide as a key for hardware indexing