### PR TITLE
updated hardware data pages for new data model

### DIFF
--- a/content/hardware-data/_index.md
+++ b/content/hardware-data/_index.md
@@ -16,90 +16,112 @@ If you have a hardware that has a single network/worker device on it, its hardwa
 
 ```json
 {
-  "id": "8978e7d4-1a55-4845-8a66-a5259236b104",
-  "arch": "x86_64",
-  "name": "node-name",
-  "state": "provisioning",
-  "allow_pxe": true,
-  "allow_workflow": true,
-  "plan_slug": "t1.small.x86",
-  "facility_code": "onprem",
-  "instance": {
-    "storage": {
-      "disks": [
-        {
-          "device": "/dev/sda",
-          "wipeTable": true,
-          "partitions": [
-            {
-              "size": 4096,
-              "label": "BIOS",
-              "number": 1
-            },
-            {
-              "size": "3993600",
-              "label": "SWAP",
-              "number": 2
-            },
-            {
-              "size": 0,
-              "label": "ROOT",
-              "number": 3
-            }
-          ]
-        }
-      ],
-      "filesystems": [
-        {
-          "mount": {
-            "point": "/",
-            "create": {
-              "options": ["-L", "ROOT"]
-            },
-            "device": "/dev/sda3",
-            "format": "ext4"
-          }
-        },
-        {
-          "mount": {
-            "point": "none",
-            "create": {
-              "options": ["-L", "SWAP"]
-            },
-            "device": "/dev/sda2",
-            "format": "swap"
-          }
-        }
-      ]
+  "id": "0eba0bf8-3772-4b4a-ab9f-6ebe93b90a94",
+  "metadata": {
+    "bonding_mode": 5,
+    "custom": {
+      "preinstalled_operating_system_version": {},
+      "private_subnets": []
     },
-    "crypted_root_password": "$6$qViImWbWFfH/a4pq$s1bpFFXMpQj1eQbHWsruLy6/",
-    "operating_system_version": {
-      "distro": "ubuntu",
-      "version": "16.04",
-      "os_slug": "ubuntu_16_04"
-    }
-  },
-  "ip_addresses": [
-    {
-      "cidr": 31,
-      "public": false,
-      "address": "172.16.1.35",
-      "enabled": true,
-      "gateway": "172.16.1.34",
-      "netmask": "255.255.255.254",
-      "network": "172.16.1.34",
-      "address_family": 4
-    }
-  ],
-  "network_ports": [
-    {
-      "data": {
-        "mac": "98:03:9b:48:de:bc"
+    "facility": {
+      "facility_code": "ewr1",
+      "plan_slug": "c2.medium.x86",
+      "plan_version_slug": ""
+    },
+    "instance": {
+      "crypted_root_password": "redacted",
+      "operating_system_version": {
+        "distro": "ubuntu",
+        "os_slug": "ubuntu_18_04",
+        "version": "18.04"
       },
-      "name": "eth0",
-      "type": "data"
-    }
-  ]
+      "storage": {
+        "disks": [
+          {
+            "device": "/dev/sda",
+            "partitions": [
+              {
+                "label": "BIOS",
+                "number": 1,
+                "size": 4096
+              },
+              {
+                "label": "SWAP",
+                "number": 2,
+                "size": 3993600
+              },
+              {
+                "label": "ROOT",
+                "number": 3,
+                "size": 0
+              }
+            ],
+            "wipe_table": true
+          }
+        ],
+        "filesystems": [
+          {
+            "mount": {
+              "create": {
+                "options": ["-L", "ROOT"]
+              },
+              "device": "/dev/sda3",
+              "format": "ext4",
+              "point": "/"
+            }
+          },
+          {
+            "mount": {
+              "create": {
+                "options": ["-L", "SWAP"]
+              },
+              "device": "/dev/sda2",
+              "format": "swap",
+              "point": "none"
+            }
+          }
+        ]
+      }
+    },
+    "manufacturer": {
+      "id": "",
+      "slug": ""
+    },
+    "state": ""
+  },
+  "network": {
+    "interfaces": [
+      {
+        "dhcp": {
+          "arch": "x86_64",
+          "hostname": "server001",
+          "ip": {
+            "address": "192.168.1.5",
+            "gateway": "192.168.1.1",
+            "netmask": "255.255.255.248"
+          },
+          "lease_time": 86400,
+          "mac": "00:00:00:00:00:00",
+          "name_servers": [],
+          "time_servers": [],
+          "uefi": false
+        },
+        "netboot": {
+          "allow_pxe": true,
+          "allow_workflow": true,
+          "ipxe": {
+            "contents": "#!ipxe",
+            "url": "http://url/menu.ipxe"
+          },
+          "osie": {
+            "base_url": "",
+            "initrd": "",
+            "kernel": "vmlinuz-x86_64"
+          }
+        }
+      }
+    ]
+  }
 }
 ```
 
@@ -107,49 +129,61 @@ If you have a hardware that has a single network/worker device on it, its hardwa
 
 The following section explains each property in the above example:
 
-| Property                                            | Description                                                                                                                                                                                                                                                                                 |
-| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| id                                                  | A UUID used to uniquely identify the hardware. The `id` can be generated using the `uuidgen` command. If you are in Packet environment, you can get the `id` from the server overview page.                                                                                                 |
-| arch                                                | The hardware architecture. Example: `x86_64`.                                                                                                                                                                                                                                               |
-| name                                                | Name of the worker node.                                                                                                                                                                                                                                                                    |
-| state                                               | The state must be set to `provisioning` for workflows.                                                                                                                                                                                                                                      |
-| allow_pxe                                           | Must be set to `true` to PXE.                                                                                                                                                                                                                                                               |
-| allow_workflow                                      | Must be `true` in order to execute a workflow.                                                                                                                                                                                                                                              |
-| facility_code                                       | For local setup, `onprem` or any other string value can be used.                                                                                                                                                                                                                            |
-| plan_slug                                           | The slug for the worker class. The value for this property depends on how you setup your workflow. While it is required if you are using the OS images from [packet-images](https://github.com/packethost/packet-images) repository, it may be left out if not used at all in the workflow. |
-| instance                                            | Holds the details for an instance.                                                                                                                                                                                                                                                          |
-| instance.storage                                    | Details for an instance storage like disks and filesystems.                                                                                                                                                                                                                                 |
-| instance.storage.disks                              | List of disk partitions.                                                                                                                                                                                                                                                                    |
-| instance.storage.disks[].device                     | Name of the disk.                                                                                                                                                                                                                                                                           |
-| instance.storage.disks[].wipeTable                  | Set to `true` to allow disk wipe.                                                                                                                                                                                                                                                           |
-| instance.storage.disks[].partitions                 | List of disk partitions.                                                                                                                                                                                                                                                                    |
-| instance.storage.disks[].partitions[].size          | Size of the partition .                                                                                                                                                                                                                                                                     |
-| instance.storage.disks[].partitions[].label         | Partition label like BIOS, SWAP or ROOT.                                                                                                                                                                                                                                                    |
-| instance.storage.disks[].partitions[].number        | The partition number.                                                                                                                                                                                                                                                                       |
-| instance.storage.filesystems                        | List of filesystems and their respective mount points.                                                                                                                                                                                                                                      |
-| instance.storage.filesystems[].mount                | Details about the filesystem to be mounted.                                                                                                                                                                                                                                                 |
-| instance.storage.filesystems[].mount.point          | Mount point for the filesystem.                                                                                                                                                                                                                                                             |
-| instance.storage.filesystems[].mount.create         | Additional details that can be provided while creating a partition.                                                                                                                                                                                                                         |
-| instance.storage.filesystems[].mount.create.options | Options to be passed to `mkfs` while creating a partition.                                                                                                                                                                                                                                  |
-| instance.storage.filesystems[].mount.device         | The device to be mounted.                                                                                                                                                                                                                                                                   |
-| instance.storage.filesystems[].mount.format         | The filesystem format.                                                                                                                                                                                                                                                                      |
-| crypted_root_password                               | The hash for root password that is used to login into the worker after provisioning. The hash can be generated using the `openssl passwd` command. For example, `openssl passwd -6 -salt xyz your-password`.                                                                                |
-| operating_system_version                            | Details about the operating system to be installed.                                                                                                                                                                                                                                         |
-| operating_system_version.distro                     | Operating system distribution name like ubuntu.                                                                                                                                                                                                                                             |
-| operating_system_version.version                    | Operating system version like 18.04 or 20.04.                                                                                                                                                                                                                                               |
-| operating_system_version.os_slug                    | A slug is a combination of operating system distro and version.                                                                                                                                                                                                                             |
-| ip_addresses                                        | Details for DHCP.                                                                                                                                                                                                                                                                           |
-| ip_addresses[].cidr                                 | The newtwork CIDR.                                                                                                                                                                                                                                                                          |
-| ip_addresses[].public                               | `false` as the worker will should be in private network.                                                                                                                                                                                                                                    |
-| ip_addresses[].address                              | The worker IP address to be requested over DHCP.                                                                                                                                                                                                                                            |
-| ip_addresses[].enabled                              | Must be set to `true`.                                                                                                                                                                                                                                                                      |
-| ip_addresses[].gateway                              | The gateway address.                                                                                                                                                                                                                                                                        |
-| ip_addresses[].netmask                              | Netmask for the private network.                                                                                                                                                                                                                                                            |
-| ip_addresses[].address_family                       | Should be set to 4 for IPv4 and 6 for IPv6.                                                                                                                                                                                                                                                 |
-| network_ports                                       | List of network devices (workers) on the hardware.                                                                                                                                                                                                                                          |
-| network_ports[].data.mac                            | MAC address of the network device (worker).                                                                                                                                                                                                                                                 |
-| network_ports[].name                                | It must set to `eth0` for a worker node.                                                                                                                                                                                                                                                    |
-| network_ports[].type                                | Set as `data`.                                                                                                                                                                                                                                                                              |
+| Property                                                     | Description                                                                                                                                                                                                                                                                                 |
+| ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| id                                                           | A UUID used to uniquely identify the hardware. The `id` can be generated using the `uuidgen` command. If you are in Packet environment, you can get the `id` from the server overview page.                                                                                                 |
+| network                                                      | Network details                                                                                                                                                                                                                                                                             |
+| network.Interfaces[]                                         | List of network interfaces on the hardware                                                                                                                                                                                                                                                  |
+| network.interfaces[].dhcp                                    | DHCP details                                                                                                                                                                                                                                                                                |
+| network.interfaces[].dhcp.mac                                | MAC address of the network device (worker)                                                                                                                                                                                                                                                  |
+| network.interfaces[].dhcp.ip                                 | IP details for DHCP                                                                                                                                                                                                                                                                         |
+| network.interfaces[].dhcp.ip.address                         | Worker IP address to be requested over DHCP                                                                                                                                                                                                                                                 |
+| network.interfaces[].dhcp.ip.gateway                         | Gateway address                                                                                                                                                                                                                                                                             |
+| network.interfaces[].dhcp.ip.netmask                         | Netmask for the private network                                                                                                                                                                                                                                                             |
+| network.interfaces[].dhcp.hostname                           | Hostname                                                                                                                                                                                                                                                                                    |
+| network.interfaces[].dhcp.lease_time                         | Expiration in secs (default: 86400)                                                                                                                                                                                                                                                         |
+| network.interfaces[].dhcp.name_servers[]                     | DNS servers                                                                                                                                                                                                                                                                                 |
+| network.interfaces[].dhcp.time_servers[]                     | NTP servers                                                                                                                                                                                                                                                                                 |
+| network.interfaces[].dhcp.arch                               | Hardware architecture, example: `x86_64`                                                                                                                                                                                                                                                    |
+| network.interfaces[].dhcp.uefi                               | Is UEFI                                                                                                                                                                                                                                                                                     |
+| network.interfaces[].netboot                                 | Netboot details                                                                                                                                                                                                                                                                             |
+| network.interfaces[].netboot.allow_pxe                       | Must be set to `true` to PXE.                                                                                                                                                                                                                                                               |
+| network.interfaces[].netboot.allow_workflow                  | Must be `true` in order to execute a workflow.                                                                                                                                                                                                                                              |
+| network.interfaces[].netboot.ipxe                            | Details for iPXE                                                                                                                                                                                                                                                                            |
+| network.interfaces[].netboot.ipxe.url                        | iPXE script URL                                                                                                                                                                                                                                                                             |
+| network.interfaces[].netboot.ipxe.contents                   | iPXE script contents                                                                                                                                                                                                                                                                        |
+| network.interfaces[].netboot.osie                            | OSIE details                                                                                                                                                                                                                                                                                |
+| network.interfaces[].netboot.osie.kernel                     | Kernel                                                                                                                                                                                                                                                                                      |
+| network.interfaces[].netboot.osie.initrd                     | Initrd                                                                                                                                                                                                                                                                                      |
+| network.interfaces[].netboot.osie.base_url                   | Base URL for the kernel and initrd                                                                                                                                                                                                                                                          |
+| metadata                                                     | Hardware metadata details                                                                                                                                                                                                                                                                   |
+| metadata.state                                               | State must be set to `provisioning` for workflows.                                                                                                                                                                                                                                          |
+| metadata.bonding_mode                                        | Bonding mode                                                                                                                                                                                                                                                                                |
+| metadata.manufacturer                                        | Manufacturer details                                                                                                                                                                                                                                                                        |
+| metadata.instance                                            | Holds the details for an instance                                                                                                                                                                                                                                                           |
+| metadata.instance.storage                                    | Details for an instance storage like disks and filesystems                                                                                                                                                                                                                                  |
+| metadata.instance.storage.disks                              | List of disk partitions                                                                                                                                                                                                                                                                     |
+| metadata.instance.storage.disks[].device                     | Name of the disk                                                                                                                                                                                                                                                                            |
+| metadata.instance.storage.disks[].wipe_table                 | Set to `true` to allow disk wipe.                                                                                                                                                                                                                                                           |
+| metadata.instance.storage.disks[].partitions                 | List of disk partitions                                                                                                                                                                                                                                                                     |
+| metadata.instance.storage.disks[].partitions[].size          | Size of the partition                                                                                                                                                                                                                                                                       |
+| metadata.instance.storage.disks[].partitions[].label         | Partition label like BIOS, SWAP or ROOT                                                                                                                                                                                                                                                     |
+| metadata.instance.storage.disks[].partitions[].number        | Partition number                                                                                                                                                                                                                                                                            |
+| metadata.instance.storage.filesystems                        | List of filesystems and their respective mount points                                                                                                                                                                                                                                       |
+| metadata.instance.storage.filesystems[].mount                | Details about the filesystem to be mounted                                                                                                                                                                                                                                                  |
+| metadata.instance.storage.filesystems[].mount.point          | Mount point for the filesystem                                                                                                                                                                                                                                                              |
+| metadata.instance.storage.filesystems[].mount.create         | Additional details that can be provided while creating a partition                                                                                                                                                                                                                          |
+| metadata.instance.storage.filesystems[].mount.create.options | Options to be passed to `mkfs` while creating a partition                                                                                                                                                                                                                                   |
+| metadata.instance.storage.filesystems[].mount.device         | Device to be mounted                                                                                                                                                                                                                                                                        |
+| metadata.instance.storage.filesystems[].mount.format         | Filesystem format                                                                                                                                                                                                                                                                           |
+| metadata.instance.crypted_root_password                      | Hash for root password that is used to login into the worker after provisioning. The hash can be generated using the `openssl passwd` command. For example, `openssl passwd -6 -salt xyz your-password`.                                                                                    |
+| metadata.operating_system_version                            | Details about the operating system to be installed                                                                                                                                                                                                                                          |
+| metadata.operating_system_version.distro                     | Operating system distribution name, like ubuntu                                                                                                                                                                                                                                             |
+| metadata.operating_system_version.version                    | Operating system version, like 18.04 or 20.04                                                                                                                                                                                                                                               |
+| metadata.operating_system_version.os_slug                    | A slug is a combination of operating system distro and version.                                                                                                                                                                                                                             |
+| metadata.facility                                            | Facility details                                                                                                                                                                                                                                                                            |
+| metadata.facility.plan_slug                                  | The slug for the worker class. The value for this property depends on how you setup your workflow. While it is required if you are using the OS images from [packet-images](https://github.com/packethost/packet-images) repository, it may be left out if not used at all in the workflow. |
+| metadata.facility.facility_code                              | For local setup, `onprem` or any other string value can be used.                                                                                                                                                                                                                            |
 
 ### The Minimal Hardware Data
 
@@ -157,32 +191,37 @@ While the hardware data is essential, not all the properties are required for ev
 In fact, it's upto a workflow designer how they want to use the data in their workflow.
 Therefore, you may start with the minimal data given below and only add the properties you would want to use in your workflow.
 
-```
+```json
 {
-  "id": "ce2e62ed-826f-4485-a39f-a82bb74338e2",
-  "arch": "x86_64",
-  "allow_pxe": true,
-  "allow_workflow": true,
-  "facility_code": "onprem",
-  "ip_addresses": [
-    {
-      "address": "192.168.1.5",
-      "address_family": 4,
-      "enabled": true,
-      "gateway": "192.168.1.1",
-      "management": true,
-      "netmask": "255.255.255.248",
-      "public": false
-    }
-  ],
-  "network_ports": [
-    {
-      "data": {
-        "mac": "ec:0d:9a:bf:ff:dc"
-      },
-      "name": "eth0",
-      "type": "data"
-    }
-  ]
+  "id": "0eba0bf8-3772-4b4a-ab9f-6ebe93b90a94",
+  "metadata": {
+    "facility": {
+      "facility_code": "ewr1",
+      "plan_slug": "c2.medium.x86",
+      "plan_version_slug": ""
+    },
+    "instance": {},
+    "state": "provisioning"
+  },
+  "network": {
+    "interfaces": [
+      {
+        "dhcp": {
+          "arch": "x86_64",
+          "ip": {
+            "address": "192.168.1.5",
+            "gateway": "192.168.1.1",
+            "netmask": "255.255.255.248"
+          },
+          "mac": "00:00:00:00:00:00",
+          "uefi": false
+        },
+        "netboot": {
+          "allow_pxe": true,
+          "allow_workflow": true
+        }
+      }
+    ]
+  }
 }
 ```

--- a/content/setup/packet-with-terraform/hardware-data.md
+++ b/content/setup/packet-with-terraform/hardware-data.md
@@ -28,33 +28,38 @@ https://api.packet.net/devices/{device_id}
 
 - Here is the minimal hardware data that can get you started with the [Hello World!](/examples/hello-world) example.
 
-```
+```json
 {
-  "id": "ce2e62ed-826f-4485-a39f-a82bb74338e2",
-  "arch": "x86_64",
-  "allow_pxe": true,
-  "allow_workflow": true,
-  "facility_code": "onprem",
-  "ip_addresses": [
-    {
-      "address": "192.168.1.5",
-      "address_family": 4,
-      "enabled": true,
-      "gateway": "192.168.1.1",
-      "management": true,
-      "netmask": "255.255.255.248",
-      "public": false
-    }
-  ],
-  "network_ports": [
-    {
-      "data": {
-        "mac": "ec:0d:9a:bf:ff:dc"
-      },
-      "name": "eth0",
-      "type": "data"
-    }
-  ]
+  "id": "0eba0bf8-3772-4b4a-ab9f-6ebe93b90a94",
+  "metadata": {
+    "facility": {
+      "facility_code": "ewr1",
+      "plan_slug": "c2.medium.x86",
+      "plan_version_slug": ""
+    },
+    "instance": {},
+    "state": ""
+  },
+  "network": {
+    "interfaces": [
+      {
+        "dhcp": {
+          "arch": "x86_64",
+          "ip": {
+            "address": "192.168.1.5",
+            "gateway": "192.168.1.1",
+            "netmask": "255.255.255.248"
+          },
+          "mac": "00:00:00:00:00:00",
+          "uefi": false
+        },
+        "netboot": {
+          "allow_pxe": true,
+          "allow_workflow": true
+        }
+      }
+    ]
+  }
 }
 ```
 


### PR DESCRIPTION
As the hardware data model is being updated by https://github.com/tinkerbell/tink/pull/64, https://github.com/tinkerbell/boots/pull/27, and https://github.com/tinkerbell/hegel/pull/13, the docs should also reflect the changes.

Also sorted the json structures for better predictability