### PR TITLE
Updated hardware-data.json example in Vagrant setup guide

### DIFF
--- a/content/setup/local-with-vagrant/_index.md
+++ b/content/setup/local-with-vagrant/_index.md
@@ -219,8 +219,8 @@ You can login with the username `root` and no password is required.
 > Note: If you have a 4k monitor a few notes about how to make the [UI
 > bigger](https://github.com/tinkerbell/tinkerbell.org/pull/76#discussion_r442151095)
 
-In the meantime if you look back at the terminal where you are tailing the logs
-from the Tinkerbell provisioner you will see the workflow running:
+In the meantime, if you look back at the terminal where you are tailing the logs
+from the Tinkerbell provisioner, you will see the workflow running:
 
 ```
 tink-server_1  | Received action status: workflow_id:"a8984b09-566d-47ba-b6c5-fbe482d8ad7f" task_name:"hello world" action_name:"hello_world" action_status:ACTION_SUCCESS message:"Finished Execution Successfully" worker_id:"ce2e62ed-826f-4485-a39f-a82bb74338e2"

--- a/content/setup/local-with-vagrant/_index.md
+++ b/content/setup/local-with-vagrant/_index.md
@@ -87,8 +87,8 @@ Now that the provisioner is running we can follow the [example called "Hello
 world"](/examples/hello-world). We will run through it for our Vagrant setup
 here.
 
-It is useful to keep a ssh connection that shows logs from the Tinkerbell
-provisioner, because it helps to learn what it is doing. Open a new terminal,
+It is useful to keep a an eye on the logs from the Tinkerbell
+provisioner, because it helps to see what it is doing. Open a new terminal,
 ssh in the provisioner as we did before and run `docker-compose` to tail logs:
 
 ```
@@ -126,31 +126,34 @@ Next we register the worker with Tinkerbell:
 ```
 vagrant@provisioner:/vagrant/deploy$ cat > hardware-data.json <<EOF
 {
-  "id": "ce2e62ed-826f-4485-a39f-a82bb74338e2",
-  "arch": "x86_64",
-  "allow_pxe": true,
-  "allow_workflow": true,
-  "facility_code": "onprem",
-  "ip_addresses": [
-    {
-      "address": "192.168.1.5",
-      "address_family": 4,
-      "enabled": true,
-      "gateway": "192.168.1.1",
-      "management": true,
-      "netmask": "255.255.255.248",
-      "public": false
-    }
-  ],
-  "network_ports": [
-    {
-      "data": {
-        "mac": "08:00:27:00:00:01"
-      },
-      "name": "eth0",
-      "type": "data"
-    }
-  ]
+  "id": "0eba0bf8-3772-4b4a-ab9f-6ebe93b90a94",
+  "metadata": {
+    "facility": {
+      "facility_code": "onprem"
+    },
+    "instance": {},
+    "state": ""
+  },
+  "network": {
+    "interfaces": [
+      {
+        "dhcp": {
+          "arch": "x86_64",
+          "ip": {
+            "address": "192.168.1.5",
+            "gateway": "192.168.1.1",
+            "netmask": "255.255.255.248"
+          },
+          "mac": "08:00:27:00:00:01",
+          "uefi": false
+        },
+        "netboot": {
+          "allow_pxe": true,
+          "allow_workflow": true
+        }
+      }
+    ]
+  }
 }
 EOF
 
@@ -205,7 +208,7 @@ $ cd deploy/vagrant
 $ vagrant up worker
 ```
 
-I using VirtualBox, the worker shows up in a UI. If you followed all the steps
+If using VirtualBox, the worker shows up in a UI. If you followed all the steps
 correctly, Tinkerbell will netboot a custom AlpineOS and you will see a login screen.
 This OS runs in RAM, so any changes you make won't be persisted between reboots.
 
@@ -216,9 +219,8 @@ You can login with the username `root` and no password is required.
 > Note: If you have a 4k monitor a few notes about how to make the [UI
 > bigger](https://github.com/tinkerbell/tinkerbell.org/pull/76#discussion_r442151095)
 
-In the meantime you can get back looking at the terminal where we are watching
-the logs from the Tinkerbell provisioner until you will see the workflow
-running:
+In the meantime if you look back at the terminal where you are tailing the logs
+from the Tinkerbell provisioner you will see the workflow running:
 
 ```
 tink-server_1  | Received action status: workflow_id:"a8984b09-566d-47ba-b6c5-fbe482d8ad7f" task_name:"hello world" action_name:"hello_world" action_status:ACTION_SUCCESS message:"Finished Execution Successfully" worker_id:"ce2e62ed-826f-4485-a39f-a82bb74338e2"


### PR DESCRIPTION
We introduced a breaking change in the hardware data model which among other things broke the Vagrant setup guide. This fixes it.