### PR TITLE
Updating Contributors page with a join us CTA

### DIFF
--- a/content/contributors/_index.md
+++ b/content/contributors/_index.md
@@ -7,3 +7,6 @@ disableToc = "true"
 +++
 
 {{%contributors /%}}
+
+
+Want to help us build something awesome? Join us on [GitHub](github.com/tinkerbell/tinkerbell.org) or [Slack](https://slack.packet.com).


### PR DESCRIPTION
## Description

Adding information on how to get involved in the project.

## Why is this needed

So people know how to get involved in the OSS Tinkerbell Project.

Fixes: #

## How Has This Been Tested?
Just adding a line at the bottom of the page


## How are existing users impacted? What migration steps/scripts do we need?

No one is impacted.


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
