### PR TITLE
Update _index.md

### DIFF
--- a/content/documentation/_index.md
+++ b/content/documentation/_index.md
@@ -13,7 +13,7 @@ Everything you need to know about Tinkerbell and its major component microservic
 
 Tinkerbell is an open-source, bare metal provisioning engine, built and maintained by the team at Packet.
 
-- Interested in contributing? Check out our [Contributors' Page](/contributors).
+- Interested in collaborating? Join our growing community of [Contributors](/contributors) on [GitHub](https://github.com/tinkerbell) or [Slack](https://slack.packet.com)
 
 ## What's Powering Tinkerbell?
 


### PR DESCRIPTION
Join our growing community of [Contributors](/contributors) on [GitHub](https://github.com/tinkerbell) or [Slack](https://slack.packet.com)

## Description

Shift the wording of the collaboration call to action from showing off our current contributors, to include links to contribute / communicate. Ideally, this will be a link to a contribution page (how to contribute) but this is a baby step.

## Why is this needed

The previous version read as 'want to join? here are the people who already have' but the link implied that it was a page on HOW to contribute. Kind of a bait and switch.

Fixes: #

## How Has This Been Tested?

Locally rebuilt and applied. No issues.

## How are existing users impacted? What migration steps/scripts do we need?

No impact. No migration steps / scripts needed.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
