### PR TITLE
Vagrant extended docs page

### DIFF
--- a/content/docs/setup/local-with-vagrant/_index.md
+++ b/content/docs/setup/local-with-vagrant/_index.md
@@ -259,4 +259,6 @@ docker exec -i deploy_tink-cli_1 tink workflow events a8984b09-566d-47ba-b6c5-fb
 
 Getting set up locally is a good way to sample Tinkerbell's functionality. The Vagrant set up is not necessarily intended to be persistent, but while it's up and running, you can use the Provisioner to test out the CLI commands or just explore the stack.
 
+If you are looking to extend your local setup to develop or test out other workflows, check out the [Extending the Vagrant Setup](/docs/setup/local-with-vagrant/extending-vagrant) doc.
+
 That's it! Let us know what you think about it on [Slack](/community/slack).

--- a/content/docs/setup/local-with-vagrant/extending-vagrant.md
+++ b/content/docs/setup/local-with-vagrant/extending-vagrant.md
@@ -1,0 +1,60 @@
++++
+title = "Extending the Vagrant Setup"
+date = 2020-08-14
+draft = false
+weight = 10
+toc = true
++++
+
+If you have followed the guide to getting Vagrant set up locally, you might be interested in other things you can do with it. There are some steps that you may need to take in order to make the setup a bit more functional.
+
+## Getting Your Worker Connected to the Internet
+
+A Worker machine created by Vagrant is not Internet facing because the newly deployed host uses the tink server as its network gateway. If you are looking to develop more workflows, it might be useful to allow the Worker access to the Internet to do things like run `apt-get update` or pull down images directly from Docker.
+
+In order to provide this functionality, you need to configure `iptables` so the network gateway can speak to the Internet, allowing the Worker machine Internet access.
+
+SSH into the Provisioner.
+
+Set the environment variables of the two network interfaces:
+
+```
+export main=<public_ip_iface>
+export vagrant=<tinkerbell_ip_iface> 
+```
+
+Enable Internet forwarding on the tink server. (Note: This is not permanent, you would need to edit `/etc/sysctl` to make it permanent.)
+
+```
+echo 1 > /proc/sys/net/ipv4/ip_forward
+```
+
+Forward traffic from the vagrant network to main interface.
+
+```
+iptables -A FORWARD -i $vagrant -o $main -j ACCEPT
+```
+
+Forward the existing traffic back from the main interface to the vagrant network.
+
+```
+iptables -A FORWARD -i $main -o $vagrant -m state --state ESTABLISHED,RELATED \
+         -j ACCEPT
+```
+
+Translate addresses so traffic appears to have come from the correct address.
+
+```
+iptables -t nat -A POSTROUTING -o $vagrant -j MASQUERADE
+```
+
+## Running Tests with Vagrant
+
+If you are developing on Tinkerbell, it might be handy to know that the Vagrant setup serves as the backbone of some of the end-to-end testing. The scripts that set up and run the tests are in the `tink` repository, in the `test/_vagrant` directory.
+
+The requirements for the tests are the same as the Vagrant setup itself, along with Go installed on your local machine.
+
+To run the tests, run the `go test` command, pointed at the `test/_vagrant` directory.
+```
+go test ./test/_vagrant/...
+```

--- a/content/docs/setup/local-with-vagrant/extending-vagrant.md
+++ b/content/docs/setup/local-with-vagrant/extending-vagrant.md
@@ -20,7 +20,7 @@ Set the environment variables of the two network interfaces:
 
 ```
 export main=<public_ip_iface>
-export vagrant=<tinkerbell_ip_iface> 
+export vagrant=<tinkerbell_ip_iface>
 ```
 
 Enable Internet forwarding on the tink server. (Note: This is not permanent, you would need to edit `/etc/sysctl` to make it permanent.)
@@ -55,6 +55,7 @@ If you are developing on Tinkerbell, it might be handy to know that the Vagrant 
 The requirements for the tests are the same as the Vagrant setup itself, along with Go installed on your local machine.
 
 To run the tests, run the `go test` command, pointed at the `test/_vagrant` directory.
+
 ```
 go test ./test/_vagrant/...
 ```


### PR DESCRIPTION
## Description

This PR adds a page to the Vagrant setup expanding on uses for running Tinkerbell in Vagrant outside of the initial setup/tutorial doc.

## Why is this needed

Fixes: https://github.com/tinkerbell/tinkerbell.org/issues/112

## How Has This Been Tested?

Ran a local markdown build, will also test with preview build

## How are existing users impacted? What migration steps/scripts do we need?

shouldn't have any affect on existing users
