### PR TITLE
Ephemeral data

### DIFF
--- a/content/docs/workflows/_index.md
+++ b/content/docs/workflows/_index.md
@@ -56,7 +56,7 @@ You can view the events and the state of a workflow during or after its executio
 
 Ephemeral data is data that is shared between Workers as they execute workflows. Ephemeral data is stored in `/workflow/<workflow_id>`.
 
-Initially the directory is empty; you populate with it by having a [template's actions (scripts, etc)](/docs/templates) write to it. 
+Initially the directory is empty; you populate with it by having a [template's actions (scripts, etc)](/docs/templates) write to it.
 
 As the workflow progresses, subsequent actions on a Worker can read any ephemeral data that's been created by previous actions on other Workers as well as update that file with any changes. After the workflow finishes, any future actions on additional Workers will be able to read from that directory and see the updates.
 

--- a/content/docs/workflows/_index.md
+++ b/content/docs/workflows/_index.md
@@ -1,16 +1,16 @@
 +++
 title = "Workflows"
-date = 2020-07-28
+date = 2020-08-28
 draft = false
 weight = 30
 toc = true
 +++
 
-A workflow is the complete set of operations to be run on a Worker. It consists of two building blocks: a Worker's [hardware data](/hardware-data) and a [template](/docs/templates).
+A workflow is the complete set of operations to be run on a Worker. It consists of two building blocks: a Worker's [hardware data](/docs/hardware-data) and a [template](/docs/templates).
 
 ## Creating a Workflow
 
-You create a workflow with the [`tink workflow create`](/cli-reference/workflow/#tink-workflow-create)command, which takes a template ID and a JSON object that identifies the Worker, and combines them into a workflow. The workflow is stored in the database on the Provisioner and returns a workflow ID.
+You create a workflow with the [`tink workflow create`](/docs/cli-reference/workflow/#tink-workflow-create)command, which takes a template ID and a JSON object that identifies the Worker, and combines them into a workflow. The workflow is stored in the database on the Provisioner and returns a workflow ID.
 
 For example,
 
@@ -23,7 +23,7 @@ tink workflow create \
 
 The template ID is `75ab8483-6f42-42a9-a80d-a9f6196130df`. The MAC address of the Worker is `08:00:27:00:00:01`, which should match the MAC address of hardware data that you have already created to identify that Worker. It is mapped to `device_1`, which is where the MAC address will be substituted into the template when the workflow is created.
 
-After creating a workflow, you can retrieve it from the database by ID with [`tink workflow get`](/cli-reference/workflow/#tink-workflow-get). This is particularly useful to check to see that the MAC address or IP Address of the Worker was correctly substituted when you created the workflow.
+After creating a workflow, you can retrieve it from the database by ID with [`tink workflow get`](/docs/cli-reference/workflow/#tink-workflow-get). This is particularly useful to check to see that the MAC address or IP Address of the Worker was correctly substituted when you created the workflow.
 
 ```
 tink workflow get a8984b09-566d-47ba-b6c5-fbe482d8ad7f
@@ -40,7 +40,7 @@ tasks:
         timeout: 60
 ```
 
-In addition, you can list all the workflows stored in the database with [`tink workflow list`](/cli-reference/workflow/#tink-workflow-list). Delete a workflow with [`tink workflow delete`](/cli-reference/workflow/#tink-workflow-delete).
+In addition, you can list all the workflows stored in the database with [`tink workflow list`](/docs/cli-reference/workflow/#tink-workflow-list). Delete a workflow with [`tink workflow delete`](/docs/cli-reference/workflow/#tink-workflow-delete).
 
 ## Workflow Execution
 
@@ -50,7 +50,7 @@ On the first boot, the Worker is PXE booted, asks Boots for it's IP address, and
 
 If there are no workflows defined for the Worker, the Provisioner will ignore the Worker's request. If as a part of the workflow, a new OS is installed and completes successfully, then the boot request (after reboot) will be handled by newly installed OS. If as a part of the workflow, an OS is **not** installed, then the Worker after reboot will request PXE-boot from the Provisioner.
 
-You can view the events and the state of a workflow during or after its execution with the tink CLI using the [`tink workflow events`](/docs/cli-reference/workflow/#tink-workflow-events) an the [`tink workflow state`](/cli-reference/workflow/#tink-workflow-state) commands.
+You can view the events and the state of a workflow during or after its execution with the tink CLI using the [`tink workflow events`](/docs/cli-reference/workflow/#tink-workflow-events) an the [`tink workflow state`](/docs/cli-reference/workflow/#tink-workflow-state) commands.
 
 ## Ephemeral Data
 

--- a/content/docs/workflows/_index.md
+++ b/content/docs/workflows/_index.md
@@ -6,7 +6,7 @@ weight = 30
 toc = true
 +++
 
-A workflow is the complete set of operations to be run on a Worker. It consists of two building blocks: a Worker's [hardware data](/hardware-data) and a [template](/concepts/#template).
+A workflow is the complete set of operations to be run on a Worker. It consists of two building blocks: a Worker's [hardware data](/hardware-data) and a [template](/docs/templates).
 
 ## Creating a Workflow
 
@@ -50,12 +50,19 @@ On the first boot, the Worker is PXE booted, asks Boots for it's IP address, and
 
 If there are no workflows defined for the Worker, the Provisioner will ignore the Worker's request. If as a part of the workflow, a new OS is installed and completes successfully, then the boot request (after reboot) will be handled by newly installed OS. If as a part of the workflow, an OS is **not** installed, then the Worker after reboot will request PXE-boot from the Provisioner.
 
-You can view the events and the state of a workflow during or after its execution with the tink CLI using the [`tink workflow events`](/cli-reference/workflow/#tink-workflow-events) an the [`tink workflow state`](/cli-reference/workflow/#tink-workflow-state) commands.
+You can view the events and the state of a workflow during or after its execution with the tink CLI using the [`tink workflow events`](/docs/cli-reference/workflow/#tink-workflow-events) an the [`tink workflow state`](/cli-reference/workflow/#tink-workflow-state) commands.
 
 ## Ephemeral Data
 
-The workers that are part of a workflow might need to share data. This can take the form of a light JSON like below, or some binary files that other workers might require to complete their action.
-For instance, a worker may add the following data:
+Ephemeral data is data that is shared between Workers as they execute workflows. Ephemeral data is stored in `/workflow/<workflow_id>`.
+
+Initially the directory is empty; you populate with it by having a [template's actions (scripts, etc)](/docs/templates) write to it. 
+
+As the workflow progresses, subsequent actions on a Worker can read any ephemeral data that's been created by previous actions on other Workers as well as update that file with any changes. After the workflow finishes, any future actions on additional Workers will be able to read from that directory and see the updates.
+
+The data can take the form of a light JSON like below, or some binary files that other workers might require to complete their action. There is a 10 MB limit for ephemeral data, because it gets pushed to and from the tink-server and workers with every action, so it needs to be pretty light.
+
+For instance, a Worker may write the following data:
 
 ```json
 {
@@ -83,4 +90,4 @@ The other worker may retrieve and use this data and eventually add some more:
 }
 ```
 
-Ephemeral data is passed as a file that is stored in the database that is accessed and modified in the execution of the workflow. You can get the ephemeral data associated with a workflow with the [`tink workflow data`](/cli-reference/workflow/#tink-workflow-data) tink CLI command.
+You can get the ephemeral data associated with a workflow with the [`tink workflow data`](/docs/cli-reference/workflow/#tink-workflow-data) tink CLI command.

--- a/content/docs/workflows/_index.md
+++ b/content/docs/workflows/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "Workflows"
-date = 2020-08-28
+date = 2020-09-01
 draft = false
 weight = 30
 toc = true
@@ -44,7 +44,7 @@ In addition, you can list all the workflows stored in the database with [`tink w
 
 ## Workflow Execution
 
-On the first boot, the Worker is PXE booted, asks Boots for it's IP address, and loads into OSIE. It then asks the `tink-server` for workflows that match its MAC or IP address. Those workflows are then executed onto the Worker.
+On the first boot, the Worker is PXE booted, asks Boots for it's IP address, and loads OSIE. OSIE provides and runs the `tink-worker` container and asks the `tink-server` for workflows that match its MAC or IP address. `tink-worker` then executes those workflows.
 
 ![Architecture](/images/docs/ephemeral-data.png)
 
@@ -54,13 +54,13 @@ You can view the events and the state of a workflow during or after its executio
 
 ## Ephemeral Data
 
-Ephemeral data is data that is shared between Workers as they execute workflows. Ephemeral data is stored in `/workflow/<workflow_id>`.
+Ephemeral data is data that is shared between Workers as they execute workflows. Ephemeral data is stored at `/workflow/<workflow_id>` in each tink-worker.
 
-Initially the directory is empty; you populate with it by having a [template's actions (scripts, etc)](/docs/templates) write to it.
+Initially the directory is empty; you populate with it by having a [template's actions (scripts, etc)](/docs/templates) write to it. Then, the content in `/workflow/<workflow_id>` is pushed back to the database and from the database, pushed out to the other Workers.
 
-As the workflow progresses, subsequent actions on a Worker can read any ephemeral data that's been created by previous actions on other Workers as well as update that file with any changes. After the workflow finishes, any future actions on additional Workers will be able to read from that directory and see the updates.
+As the workflow progresses, subsequent actions on a Worker can read any ephemeral data that's been created by previous actions on other Workers, as well as update that file with any changes. Ephemeral data is only preserved through the life of a single workflow. Each workflow that executes gets an empty file.
 
-The data can take the form of a light JSON like below, or some binary files that other workers might require to complete their action. There is a 10 MB limit for ephemeral data, because it gets pushed to and from the tink-server and workers with every action, so it needs to be pretty light.
+The data can take the form of a light JSON like below, or some binary files that other workers might require to complete their action. There is a 10 MB limit for ephemeral data, because it gets pushed to and from the tink-server and tink-worker with every action, so it needs to be pretty light.
 
 For instance, a Worker may write the following data:
 


### PR DESCRIPTION
## Description

Updates the description of ephemeral data.

## Why is this needed

Previous description was a little light on the tink-worker view of ephemeral data and how it's read/written.

Note - this PR does not update the diagram, it could use some work, method is tbd.

## How Has This Been Tested?
local markdown, prettier, and will preview build

## How are existing users impacted? What migration steps/scripts do we need?
No impact to users.
