### PR TITLE
Extending Vagrant setup to reuse osie.tar.gz

### DIFF
--- a/content/docs/setup/local-with-vagrant/extending-vagrant.md
+++ b/content/docs/setup/local-with-vagrant/extending-vagrant.md
@@ -59,3 +59,27 @@ To run the tests, run the `go test` command, pointed at the `test/_vagrant` dire
 ```
 go test ./test/_vagrant/...
 ```
+
+## Reusing osie.tar.gz
+
+While playing with Tinkerbell locally, it becomes a pain to download `osie.tar.gz` as part of the provisioner setup each time you recreate the stack.
+However, we can skip the download and resuse existing `osie.tar.gz` by setting the `TB_OSIE_TAR` environment variable.
+Check [setup.sh](https://github.com/tinkerbell/tink/blob/master/setup.sh#L259) for reference.
+
+Download Osie before starting the setup
+
+```
+curl  https://tinkerbell-oss.s3.amazonaws.com/osie-uploads/latest.tar.gz -o osie.tar.gz
+```
+
+Move the downloaded file to `tink/deploy/vagrant/`.
+Now, set the environment variable in `tink/deploy/vagrant/scripts/tinkerbell.sh` before it executes `setup.sh`.
+
+```
+...
+export TB_OSIE_TAR='/vagrant/deploy/vagrant/osie.tar.gz'
+./setup.sh
+...
+```
+
+Start the vagrant setup.


### PR DESCRIPTION
## Description

The PR adds details about how we can extend the vagrant setup to reuse `osie.tar.gz`.
Preview [here](https://deploy-preview-131--festive-goldwasser-489842.netlify.app/docs/setup/local-with-vagrant/extending-vagrant/#reusing-osietargz).

## Why is this needed

It helps to reduce the provisioner setup time, resulting in better user experience with the setup. 

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
