### PR TITLE
Change maintenance status in README to experimental.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![](https://img.shields.io/badge/Stability-Maintained-green.svg)
+![](https://img.shields.io/badge/Stability-Experimental-red.svg)
 
 # Tinkerbell
 
@@ -7,7 +7,8 @@ For complete documentation visit [tinkerbell.org](https://tinkerbell.org/)
 Tinkerbell is a bare metal provisioning engine.
 It’s built and maintained with love by the team at Packet.
 
-This repository is [Maintained](https://github.com/packethost/standards/blob/master/maintained-statement.md) meaning that this software is supported by Packet and its community - available to use in production environments.
+This repository is [Experimental](https://github.com/packethost/standards/blob/master/experimental-statement.md) meaning that it's based on untested ideas or techniques and not yet established or finalized or involves a radically new and innovative style!
+This means that support is best effort (at best!) and we strongly encourage you to NOT use this in production.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
+![](https://img.shields.io/badge/Stability-Maintained-green.svg)
+
 # Tinkerbell
 
 For complete documentation visit [tinkerbell.org](https://tinkerbell.org/)
 
 Tinkerbell is a bare metal provisioning engine.
 It’s built and maintained with love by the team at Packet.
+
+This repository is [Maintained](https://github.com/packethost/standards/blob/master/maintained-statement.md) meaning that this software is supported by Packet and its community - available to use in production environments.
 
 ## Contributing
 


### PR DESCRIPTION
## Description

Our repositories should be the example from which adjacent, competing, projects look for inspiration.

Each repository should not look entirely different from other repositories in the ecosystem, having a different layout, a different testing model, or a different logging model, for example, without reason or recommendation from the subject matter experts from the community.

We should share our improvements with each ecosystem while seeking and respecting the feedback of these communities.

Whether or not strict guidelines have been provided for the project type, our repositories should ensure that the same components are offered across the board. How these components are provided may vary, based on the conventions of the project type. GitHub provides general guidance on this which they have integrated into their user experience.

## Why is this needed

Fixes: https://github.com/tinkerbell/tinkerbell.org/issues/142