### PR TITLE
update link docs and footer icon #149

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -76,7 +76,7 @@ weight = 1
 [[menu.homepage]]
 identifier = "docs"
 name = "Docs"
-url = "/docs/"
+url = "https://docs.tinkerbell.org/"
 weight = 10
 
 [[menu.homepage]]

--- a/layouts/partials/homepage/footer.html
+++ b/layouts/partials/homepage/footer.html
@@ -10,7 +10,7 @@
                     <ul>
                           {{ range sort . "Weight"}}
                               <li> 
-                                  {{.Pre}}<a href="{{.URL | absLangURL }}">{{safeHTML .Name}}</a>{{.Post}}
+                                  <a href="{{.URL | absLangURL }}">{{.Pre}}</a>{{.Post}}
                               </li>
                           {{end}}
                     </ul>


### PR DESCRIPTION
- Update link menu docs to https://docs.tinkerbell.org/
- change footer icon + title to icon