### PR TITLE
Packet -> Equinix Metal Slack

### DIFF
--- a/content/community/slack.html
+++ b/content/community/slack.html
@@ -1,9 +1,9 @@
 +++
 title = "Community Slack"
-date = 2020-05-13T23:04:01+07:00
+date = 2020-10-21
 disableToc = "true"
 +++
 
-<p>Tinkerbell leverages Packet's community Slack channel. Please join and look for the <strong>#tinkerbell</strong> channel to get involved!</p>
+<p>Tinkerbell leverages the Equinix Metal Community Slack. Please join and look for the <strong>#tinkerbell</strong> channel to get involved!</p>
 
-<a class="button text-medium mt10" href="https://slack.packet.com/">Join Packet Community on Slack</a>
+<a class="button text-medium mt10" href="https://slack.equinixmetal.com">Join Equinix Metal Community on Slack</a>


### PR DESCRIPTION
Change Packet to Equinix Metal in copy and link

## Description

Changes copy and link from Packet to Equinix Metal on the Tinkerbell Community Slack page

## Why is this needed

Rebrand
