### PR TITLE
Correcting docs to match setup.sh

### DIFF
--- a/content/docs/setup/local-with-vagrant/_index.md
+++ b/content/docs/setup/local-with-vagrant/_index.md
@@ -69,7 +69,7 @@ vagrant@provisioner:~$
 Tinkerbell is going to be running from a container, so navigate to the `vagrant` directory, set the environment, and start the Tinkerbell stack with `docker-compose`.
 
 ```
-cd /vagrant && source .env && cd deploy
+cd /vagrant && source .envrc && cd deploy
 docker-compose up -d
 ```
 
@@ -97,7 +97,7 @@ At this point, you might want to open a ssh connection to show logs from the Pro
 ```
 cd tink/deploy/vagrant
 vagrant ssh provisioner
-cd /vagrant && source .env && cd deploy
+cd /vagrant && source .envrc && cd deploy
 docker-compose logs -f tink-server boots nginx
 ```
 


### PR DESCRIPTION
## Description

Currently the local setup section of the docs references cd /vagrant && source .env && cd deploy which according to the setup.sh should be cd /vagrant && source .envrc && cd deploy

## Why is this needed

#168 

Fixes: #168 
