### PR TITLE
bug: fix gotpl with or function

### DIFF
--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -97,7 +97,7 @@
 {{ $currentFileUniqueID := "" }}
 {{ with $currentNode.File }}{{ $currentFileUniqueID = .UniqueID }}{{ end }}
  {{with .sect }}
-  {{if and .IsSection ((not .Params.hidden) or $.showhidden)}}
+  {{if and .IsSection (or (not .Params.hidden) $.showhidden)}}
     {{safeHTML .Params.head}}
 
 


### PR DESCRIPTION
## Description

Corrects `gotpl` syntax to use `or` as a function.

## Why is this needed

In the 0.71.1 release of `hugo` there was a change that broke older compatibilities with `gotpl`. 


Fixes: #133 

## How Has This Been Tested?

I ran the site in a container locally

```bash
docker run --rm -it -v $(pwd):/src \
     -p 1313:1313 klakegg/hugo:0.82.0-alpine server
```

Then I manually tested functionality of the site; link, copy text boxes, top nav, side bars, etc.


## How are existing users impacted? What migration steps/scripts do we need?

Fixes a bug that prevented upgrading the site release to `hugo` `v0.82.0` or _latest_. 

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
