### PR TITLE
Move Slack link to CNCF, update mailing-list information

### DIFF
--- a/content/community/_index.md
+++ b/content/community/_index.md
@@ -22,7 +22,7 @@ Looking to get started with Tinkerbell? Here is the best way to do that
 
 ## Join us:
 
-- [Slack](https://slack.equinixmetal.com/): We have an active Slack channel in the Equinx Metal™ community workspace to talk all things Tinkerbell.
+- [Slack](https://slack.cncf.org/): Join us in the #tinkerbell CNCF channel to discuss all things Tinkerbell.
 - [Contribute](https://tinkerbell.org/terms/contributor-guide/): We&#39;re always looking for people with a passion for bare metal to work with us. Read over our contributor guide and jump right in.
 - [Propose](https://github.com/tinkerbell/proposals): Contribute to what we&#39;re building with a proposal. We use proposals to help publically guide the conversation about deciding on new features or pieces of code. Submit your thoughts.
 

--- a/content/community/contact.html
+++ b/content/community/contact.html
@@ -4,8 +4,18 @@ date = 2020-10-21
 disableToc = "true"
 +++
 
-<p>Reach us out at <a href="mailto:hello@tinkerbell.org" class="highlight">hello@tinkerbell.org</a></p>
-<p style="margin-bottom: 0">Tinkerbell leverages the Equinix Metal Community Slack. Please join and look for the <strong>#tinkerbell</strong> channel to get<br>involved!</p>
-<a class="button text-medium mt10" href="https://slack.equinixmetal.com" style="background: #0061D1;" target="_blank"><i class="fab fa-fw fa-slack"></i> Join Equinix Metal Community on Slack</a>
-<h1 style="margin-top: 1.5rem">Branding</h1>
+<h2 style="margin-top: 1.5rem">Slack</h2>
+
+<p style="margin-bottom: 0">
+    Want to get involved? Join us in the #tinkerbell channel on the Cloud Native Computing Foundation (CNCF) Slack workspace:
+</p>
+
+<a class="button text-medium mt10" href="https://slack.cncf.org" style="background: #0061D1;" target="_blank"><i class="fab fa-fw fa-slack"></i> Join the CNCF Community on Slack!</a>
+
+<h2 style="margin-top: 1.5rem">E-Mail</h2>
+
+Join the <a href="https://groups.google.com/g/tinkerbell-contributors">tinkerbell-contributors</a> for important news.
+
+<h2 style="margin-top: 1.5rem">Branding</h1>
+
 <p>You can find logos, icons and artwork in <a href="https://github.com/tinkerbell/artwork" class="highlight" target="_blank">this repo</a></p>

--- a/content/community/contact.html
+++ b/content/community/contact.html
@@ -16,6 +16,6 @@ disableToc = "true"
 
 Join the <a href="https://groups.google.com/g/tinkerbell-contributors">tinkerbell-contributors</a> for important news.
 
-<h2 style="margin-top: 1.5rem">Branding</h1>
+<h2 style="margin-top: 1.5rem">Branding</h2>
 
 <p>You can find logos, icons and artwork in <a href="https://github.com/tinkerbell/artwork" class="highlight" target="_blank">this repo</a></p>

--- a/content/community/contributors/_index.md
+++ b/content/community/contributors/_index.md
@@ -8,4 +8,4 @@ disableToc = "true"
 
 {{%contributors /%}}
 
-Want to help us build something awesome? Join us on [GitHub](https://github.com/tinkerbell) or [Slack](https://slack.equinixmetal.com).
+Want to help us build something awesome? Join us on [GitHub](https://github.com/tinkerbell) or [Slack](https://slack.cncf.org) (#tinkerbell).


### PR DESCRIPTION
## Description

Move Slack link to CNCF, update mailing-list information

## Why is this needed

The Slack channel has moved, and the current e-mail address listed does not facilitate discussions.

## How Has This Been Tested?

`hugo server -D`

## How are existing users impacted? What migration steps/scripts do we need?

The current Slack channel and e-mail address are not helpful to people curious about what is going on with Tinkerbell.

