### PR TITLE
Fix Community Slack Link

### DIFF
--- a/content/community/_index.md
+++ b/content/community/_index.md
@@ -22,7 +22,7 @@ Looking to get started with Tinkerbell? Here is the best way to do that
 
 ## Join us:
 
-- [Slack](https://slack.cncf.org/): Join us in the #tinkerbell CNCF channel to discuss all things Tinkerbell.
+- [Slack](https://slack.cncf.io/): Join us in the #tinkerbell CNCF channel to discuss all things Tinkerbell.
 - [Contribute](https://tinkerbell.org/terms/contributor-guide/): We&#39;re always looking for people with a passion for bare metal to work with us. Read over our contributor guide and jump right in.
 - [Propose](https://github.com/tinkerbell/proposals): Contribute to what we&#39;re building with a proposal. We use proposals to help publically guide the conversation about deciding on new features or pieces of code. Submit your thoughts.
 

--- a/content/community/contact.html
+++ b/content/community/contact.html
@@ -10,7 +10,7 @@ disableToc = "true"
     Want to get involved? Join us in the #tinkerbell channel on the Cloud Native Computing Foundation (CNCF) Slack workspace:
 </p>
 
-<a class="button text-medium mt10" href="https://slack.cncf.org" style="background: #0061D1;" target="_blank"><i class="fab fa-fw fa-slack"></i> Join the CNCF Community on Slack!</a>
+<a class="button text-medium mt10" href="https://slack.cncf.io" style="background: #0061D1;" target="_blank"><i class="fab fa-fw fa-slack"></i> Join the CNCF Community on Slack!</a>
 
 <h2 style="margin-top: 1.5rem">E-Mail</h2>
 

--- a/content/community/contributors/_index.md
+++ b/content/community/contributors/_index.md
@@ -8,4 +8,4 @@ disableToc = "true"
 
 {{%contributors /%}}
 
-Want to help us build something awesome? Join us on [GitHub](https://github.com/tinkerbell) or [Slack](https://slack.cncf.org) (#tinkerbell).
+Want to help us build something awesome? Join us on [GitHub](https://github.com/tinkerbell) or [Slack](https://slack.cncf.io) (#tinkerbell).


### PR DESCRIPTION
## Description

Prior to this PR, the community Slack link targets cncf.org ("Christina Noble Children's Foundation") rather than cncf.io.

## Why is this needed

This is the wrong link

Fixes: #

## How Has This Been Tested?
I went to slack.cncf.io and confirmed that it sent me to the correct page.


## How are existing users impacted? What migration steps/scripts do we need?

N/A


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
