### PR TITLE
Add Community meetings to Community page

### DIFF
--- a/content/community/_index.md
+++ b/content/community/_index.md
@@ -28,5 +28,6 @@ Looking to get started with Tinkerbell? Here is the best way to do that
 
 ## Keep In Touch
 
-- [Twitter](https://twitter.com/tinkerbell_oss): Follow us on Twitter for news, updates, and stories from the community [@tinkerbell_oss](https://twitter.com/tinkerbell_oss).
+- [Community Meetings](https://www.cncf.io/calendar/): Join the user focused CNCF Tinkerbell Community and developer focused Triage Party meetings. (Currently held on alternating Tuesdays @ 11a EDT)
+- [X (Twitter)](https://twitter.com/tinkerbell_oss): Follow us on X (Twitter) for news, updates, and stories from the community [@tinkerbell_oss](https://twitter.com/tinkerbell_oss).
 - [YouTube](https://www.youtube.com/channel/UCTzWInTQPvzH21KHS8jrq7A/): Our YouTube channel is a place to go to see recordings of our weekly contributors' meetings, talks, demos, and workshops about Tinkerbell and bare metal automation.


### PR DESCRIPTION


## Description

Include Community calls in the "Join Us" section of community. Given greater weight than the Twitter (now X) and Youtube channels which haven't been actively engaged.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
