### PR TITLE
Fix anchor links add page edit links:

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -59,6 +59,8 @@ geekdocLogo = "Tinkerbell-Logo-Landscape-Light.png"
 geekdocOverwriteHTMLBase = false
 geekdocMenuBundle = true
 geekdocBackToTop = false
+geekdocRepo = "https://github.com/tinkerbell/tinkerbell.org"
+geekdocEditPath = "edit/main/"
   
 [[menu.shortcuts]] 
 name = "<i class='fab fa-fw fa-slack'></i> <em>Slack</em>"

--- a/hugo.toml
+++ b/hugo.toml
@@ -56,7 +56,7 @@ geekdocDarkModeToggle = false
 geekdocDarkModeCode = false
 geekdocDarkModeDim = true
 geekdocLogo = "Tinkerbell-Logo-Landscape-Light.png"
-geekdocOverwriteHTMLBase = true
+geekdocOverwriteHTMLBase = false
 geekdocMenuBundle = true
 geekdocBackToTop = false
   

--- a/layouts/partials/page-header.html
+++ b/layouts/partials/page-header.html
@@ -1,3 +1,10 @@
+{{ $geekdocRepo := default (default false .Site.Params.geekdocRepo) .Page.Params.geekdocRepo }}
+{{ $geekdocEditPath := default (default false .Site.Params.geekdocEditPath) .Page.Params.geekdocEditPath }}
+{{ if .File }}
+  {{ $.Scratch.Set "geekdocFilePath" (default (strings.TrimPrefix hugo.WorkingDir .File.Filename) .Page.Params.geekdocFilePath) }}
+{{ else }}
+  {{ $.Scratch.Set "geekdocFilePath" false }}
+{{ end }}
 {{ $url := replace .Permalink ( printf "%s" .Site.BaseURL) "" }}
 {{ $page := .Page }}
 {{ $last := false }}
@@ -29,25 +36,34 @@
     {{ end }}
 {{ end }}
 
-
-<ol class="no">
-    {{ $len := len ($.Scratch.Get "titles") }}
-    {{ range $index, $element := $.Scratch.Get "titles" }}
-        {{ $i := sub (sub $len $index) 1 }}
-        {{ $title := index ($.Scratch.Get "titles") $i }}
-        {{ $description := index ($.Scratch.Get "descriptions") $i }}
-        {{ $url := index ($.Scratch.Get "urls") $i }}
-        {{ if ne $index 0 }}
-            {{ if ne $i 0 }}
-                <li>
-                    <a href="{{- $url -}}" title="{{- $description -}}">{{- $title -}}</a>
-                    <svg class="gdoc-icon gdoc_keyboard_arrow_right">
-                        <use xlink:href="#gdoc_keyboard_arrow_right"></use>
-                    </svg>
-                </li>
-            {{ else }}
-                <li>{{- $title -}}</li>
+<div class="no flex flex-wrap justify-between">
+  <div>
+    <ol class="no">
+        {{ $len := len ($.Scratch.Get "titles") }}
+        {{ range $index, $element := $.Scratch.Get "titles" }}
+            {{ $i := sub (sub $len $index) 1 }}
+            {{ $title := index ($.Scratch.Get "titles") $i }}
+            {{ $description := index ($.Scratch.Get "descriptions") $i }}
+            {{ $url := index ($.Scratch.Get "urls") $i }}
+            {{ if ne $index 0 }}
+                {{ if ne $i 0 }}
+                    <li>
+                        <a href="{{- $url -}}" title="{{- $description -}}">{{- $title -}}</a>
+                        <svg class="gdoc-icon gdoc_keyboard_arrow_right">
+                            <use xlink:href="#gdoc_keyboard_arrow_right"></use>
+                        </svg>
+                    </li>
+                {{ else }}
+                    <li>{{- $title -}}</li>
+                {{ end }}
             {{ end }}
         {{ end }}
-    {{ end }}
-</ol>
+    </ol>
+  </div>
+  <div>
+    <span class="editpage">
+      <svg class="gdoc-icon gdoc_code"><use xlink:href="#gdoc_code"></use></svg>
+      <a href="{{ $geekdocRepo }}/{{ path.Join $geekdocEditPath ($.Scratch.Get "geekdocFilePath") }}"> Edit page </a>
+    </span>
+  </div>
+</div>

--- a/static/custom.css
+++ b/static/custom.css
@@ -55,8 +55,10 @@ a:visited {
   padding: 0;
   margin: 0;
   font-weight: 500;
-  font-size: .875em;
+  font-size: .875rem;
 }
+
+
 
 .gdoc-nav nav section {
   margin-top: -1em;


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
They were going to the homepage with `geekdocOverwriteHTMLBase = true`.
Add page edit links to make it easier for folks to contribute.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #199 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
