### PR TITLE
Fix paths to vagrant configs in both playground and sandbox repos

### DIFF
--- a/content/docs/setup/getting_started.md
+++ b/content/docs/setup/getting_started.md
@@ -35,7 +35,7 @@ Follow these steps to create the stack on a Libvirt VM using Vagrant. Then deplo
 1. Start the stack
 
    ```bash
-   cd vagrant
+   cd stack/vagrant
    vagrant up
    # This process will take about 5-10 minutes depending on your internet connection.
    # Hook is about 400MB in size and the Ubuntu jammy image is about 500MB
@@ -513,7 +513,7 @@ Follow these steps to create the stack on a Virtualbox VM using Vagrant. Then de
 1. Start the stack
 
    ```bash
-   cd vagrant
+   cd stack/vagrant
    vagrant up
    # This process will take up to 10 minutes depending on your internet connection.
    # It will download HookOS, which is a couple hundred megabytes in size, and an Ubuntu cloud image, which is about 600MB.


### PR DESCRIPTION
## Description

Fix paths to vagrant configs in both playground and sandbox repos

## Why is this needed

To fix minor bugs while following https://tinkerbell.org/docs/setup/getting_started

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
