### PR TITLE
Another set of documentation updates

### DIFF
--- a/content/docs/additionalcomponents/ipxe.md
+++ b/content/docs/additionalcomponents/ipxe.md
@@ -7,5 +7,5 @@ geekdocDescription: "iPXE is an open-source bootloader that is used to initializ
 iPXE is an open-source bootloader that is used to initialize HookOS.
 
 This documentation is still to be written. Until that is done, please have a
-look at the [Smee DHCP documentation](https://github.com/tinkerbell/tinkerbell/blob/main/docs/technical/smee/DHCP.md)
+look at the [Smee DHCP documentation]({{< repo_tree "docs/technical/smee/DHCP.md" >}})
 for an overview of how iPXE is used in Tinkerbell.

--- a/content/docs/concepts/hardware.md
+++ b/content/docs/concepts/hardware.md
@@ -12,9 +12,9 @@ The Hardware spec describes a physical machine. Its main purpose is for IP Addre
 - Template Rendering - [here](/docs/services/tink-controller)
 
 - The current v1alpha1 specs can be found here:
-  - [Go spec](https://github.com/tinkerbell/tinkerbell/blob/main/api/v1alpha1/tinkerbell/hardware.go)
-  - [Kubernetes Custom Resource Definition](https://github.com/tinkerbell/tinkerbell/blob/main/crd/bases/tinkerbell.org_hardware.yaml)
-  - [Explorable Spec](https://doc.crds.dev/github.com/tinkerbell/tinkerbell/tinkerbell.org/Hardware/v1alpha1)
+  - [Go spec]({{< repo_tree "api/v1alpha1/tinkerbell/hardware.go" >}})
+  - [Kubernetes Custom Resource Definition]({{< repo_tree "crd/bases/tinkerbell.org_hardware.yaml" >}})
+  - [Explorable Spec](https://doc.crds.dev/github.com/tinkerbell/tinkerbell/tinkerbell.org/Hardware/v1alpha1@{{< tinkerbell_version >}})
 
 - Which services use the spec?
     Smee - Uses the IPAM fields for serving DHCP and gating of whether a machine should be given network boot info or not.

--- a/content/docs/concepts/templates.md
+++ b/content/docs/concepts/templates.md
@@ -3,7 +3,6 @@ title: 'Templates'
 draft: false
 weight: 20
 geekdocDescription: 'The resource that describes the collection of tasks and actions.'
-latestTinkerbellVersion: "https://github.com/tinkerbell/tinkerbell/tree/v0.18.3"
 ---
 
 A Template is a collection of tasks that are executed sequentially. Each Task is a collection of actions that are executed sequentially on a specific worker. Actions are the individual unit of work, such as streaming an image to a disk, writing a file, or partitioning a disk.
@@ -36,7 +35,7 @@ tasks: []
 - global_timeout `int`: An integer that describes the global timeout in seconds for the template.
 - tasks `[]task`: A list of task objects. Required.
 
-The Go struct for Tasks is found [here]({{< stringparam "latestTinkerbellVersion" >}}/api/v1alpha1/tinkerbell/workflow.go).
+The Go struct for Tasks is found [here]({{< repo_tree "api/v1alpha1/tinkerbell/workflow.go" >}}).
 
 ## Task
 
@@ -334,12 +333,12 @@ Values from the Hardware spec (currently, only [Disks][Hardware data contract] a
 
 [CRD]: <https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/>
 [Standard Go template functions]: <https://golang.org/pkg/text/template/>
-[Tinkerbell custom functions]: {{< stringparam "latestTinkerbellVersion" >}}/tink/controller/internal/workflow/template_funcs.go
-[Hardware data contract]: {{< stringparam "latestTinkerbellVersion" >}}/tink/controller/internal/workflow/reconciler.go#L401
-[Template Kubernetes CRD]: {{< stringparam "latestTinkerbellVersion" >}}/crd/bases/tinkerbell.org_templates.yaml
-[Template Go struct definition]: {{< stringparam "latestTinkerbellVersion" >}}/api/v1alpha1/tinkerbell/template.go#L36
-[Explorable Template Spec]: <https://doc.crds.dev/github.com/tinkerbell/tinkerbell/tinkerbell.org/Template/v1alpha1>
-[Task Go struct definition]: {{< stringparam "latestTinkerbellVersion" >}}/api/v1alpha1/tinkerbell/workflow.go#L208
-[Workflow Kubernetes CRD]: <{{< stringparam "latestTinkerbellVersion" >}}/crd/bases/tinkerbell.org_workflows.yaml>
+[Tinkerbell custom functions]: {{< repo_tree "tink/controller/internal/workflow/template_funcs.go" >}}
+[Hardware data contract]: {{< repo_tree "tink/controller/internal/workflow/reconciler.go#L401" >}}
+[Template Kubernetes CRD]: {{< repo_tree "crd/bases/tinkerbell.org_templates.yaml" >}}
+[Template Go struct definition]: {{< repo_tree "api/v1alpha1/tinkerbell/template.go#L36" >}}
+[Explorable Template Spec]: https://doc.crds.dev/github.com/tinkerbell/tinkerbell/tinkerbell.org/Hardware/v1alpha1@{{< tinkerbell_version >}}
+[Task Go struct definition]: {{< repo_tree "api/v1alpha1/tinkerbell/workflow.go#L208" >}}
+[Workflow Kubernetes CRD]: {{< repo_tree "crd/bases/tinkerbell.org_workflows.yaml" >}}
 [Tink Controller]: /docs/services/tink-controller
 [Actions repo]: <https://github.com/tinkerbell/actions>

--- a/content/docs/concepts/templates.md
+++ b/content/docs/concepts/templates.md
@@ -283,14 +283,12 @@ spec:
     device_1: 02:00:00:00:00:01
 ```
 
-{{< hint type=note >}}
-If the Template is defined as part of a Helm chart, you will need to escape
-the Go templates to make sure that Helm doesn't try to instantiate the template.
-One way to do so would be the following:
-```yaml
-worker: "{{ `{{.device_1}}` }}"
-```
-{{< /hint >}}
+> **Note**:
+> If the Template is defined as part of a Helm chart, you will need to escape the Go templates to make sure that Helm doesn't try to instantiate the template. One way to do so would be the following:
+>
+> ```yaml
+>  worker: "{{ `{{.device_1}}` }}"
+>  ```
 
 ### Available template arguments
 
@@ -303,11 +301,12 @@ Key names that are defined by a User in the Workflow spec at `spec.hardwareMap`:
 
 The following values from the [Hardware Spec]({{< repo_tree "api/v1alpha1/tinkerbell/hardware.go#L47" >}})
 can also be used:
-* Interfaces
-* Metadata
-* Disks
-* UserData
-* VendorData
+
+- Interfaces
+- Metadata
+- Disks
+- UserData
+- VendorData
 
 | source                                          | output                       |
 |-------------------------------------------------|------------------------------|
@@ -333,6 +332,7 @@ can also be used:
 
 The functions from the [Sprig templating library](https://masterminds.github.io/sprig/)
 can also be used:
+
 | source                                           | output                 |
 |--------------------------------------------------|------------------------|
 | `{{ "filename with spaces" \| replace " " "-" }}` | `filename-with-spaces` |

--- a/content/docs/concepts/templates.md
+++ b/content/docs/concepts/templates.md
@@ -287,35 +287,35 @@ spec:
 
 Key names that are defined by a User in the Workflow spec at `spec.hardwareMap`:
 
-| source | output |
-| ---    | ---    |
+| source            | output              |
+|-------------------|---------------------|
 | `{{ .device_1 }}` | `02:00:00:00:00:01` |
-| `{{ .key_name }}` | `value` |
+| `{{ .key_name }}` | `value`             |
 
 Values from the Hardware spec (currently, only [Disks][Hardware data contract] are available):
 
-| source | output |
-| ---    | ---    |
+| source                  | output                       |
+|-------------------------|------------------------------|
 | `{{ .Hardware.Disks }}` | `[ /dev/nvme0n1, /dev/sda ]` |
 
 ### Available template functions
 
 [Standard Go template functions]:
 
-| source | output |
-| ---    | ---    |
+| source                                      | output              |
+|---------------------------------------------|---------------------|
 | `{{ .device_1 \| printf "%s" }}`            | `02:00:00:00:00:01` |
-| `{{ if eq .device_1 "02:00:00:00:00:01" }}` | `true` |
-| `{{ index .Hardware.Disks 0 }}`             | `/dev/nvme0n1` |
+| `{{ if eq .device_1 "02:00:00:00:00:01" }}` | `true`              |
+| `{{ index .Hardware.Disks 0 }}`             | `/dev/nvme0n1`      |
 
 [Tinkerbell custom functions]:
 
-| source | output |
-| ---    | ---    |
+| source                                                | output           |
+|-------------------------------------------------------|------------------|
 | `{{ formatPartition ( index .Hardware.Disks 0 ) 1 }}` | `/dev/nvme0n1p1` |
-| `{{ contains .device_1 "02:00:00:00:00:01" }}`        | `true` |
-| `{{ hasPrefix .device_1 "02:00:00" }}`                | `true` |
-| `{{ hasSuffix .device_1 "00:01" }}`                   | `true` |
+| `{{ contains .device_1 "02:00:00:00:00:01" }}`        | `true`           |
+| `{{ hasPrefix .device_1 "02:00:00" }}`                | `true`           |
+| `{{ hasSuffix .device_1 "00:01" }}`                   | `true`           |
 
 ## Other Resources
 

--- a/content/docs/concepts/templates.md
+++ b/content/docs/concepts/templates.md
@@ -283,6 +283,15 @@ spec:
     device_1: 02:00:00:00:00:01
 ```
 
+{{< hint type=note >}}
+If the Template is defined as part of a Helm chart, you will need to escape
+the Go templates to make sure that Helm doesn't try to instantiate the template.
+One way to do so would be the following:
+```yaml
+worker: "{{ `{{.device_1}}` }}"
+```
+{{< /hint >}}
+
 ### Available template arguments
 
 Key names that are defined by a User in the Workflow spec at `spec.hardwareMap`:
@@ -292,11 +301,19 @@ Key names that are defined by a User in the Workflow spec at `spec.hardwareMap`:
 | `{{ .device_1 }}` | `02:00:00:00:00:01` |
 | `{{ .key_name }}` | `value`             |
 
-Values from the Hardware spec (currently, only [Disks][Hardware data contract] are available):
+The following values from the [Hardware Spec]({{< repo_tree "api/v1alpha1/tinkerbell/hardware.go#L47" >}})
+can also be used:
+* Interfaces
+* Metadata
+* Disks
+* UserData
+* VendorData
 
-| source                  | output                       |
-|-------------------------|------------------------------|
-| `{{ .Hardware.Disks }}` | `[ /dev/nvme0n1, /dev/sda ]` |
+| source                                          | output                       |
+|-------------------------------------------------|------------------------------|
+| `{{ .Hardware.Disks }}`                         | `[ /dev/nvme0n1, /dev/sda ]` |
+| `{{ (index .Hardware.Interfaces 0).DHCP.MAC }}` | `02:aa:ff:00:00:01`          |
+| `{{ .Hardware.UserData }}`                      | `#cloud-config [...]`        |
 
 ### Available template functions
 
@@ -313,9 +330,12 @@ Values from the Hardware spec (currently, only [Disks][Hardware data contract] a
 | source                                                | output           |
 |-------------------------------------------------------|------------------|
 | `{{ formatPartition ( index .Hardware.Disks 0 ) 1 }}` | `/dev/nvme0n1p1` |
-| `{{ contains .device_1 "02:00:00:00:00:01" }}`        | `true`           |
-| `{{ hasPrefix .device_1 "02:00:00" }}`                | `true`           |
-| `{{ hasSuffix .device_1 "00:01" }}`                   | `true`           |
+
+The functions from the [Sprig templating library](https://masterminds.github.io/sprig/)
+can also be used:
+| source                                           | output                 |
+|--------------------------------------------------|------------------------|
+| `{{ "filename with spaces" \| replace " " "-" }}` | `filename-with-spaces` |
 
 ## Other Resources
 
@@ -334,7 +354,6 @@ Values from the Hardware spec (currently, only [Disks][Hardware data contract] a
 [CRD]: <https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/>
 [Standard Go template functions]: <https://golang.org/pkg/text/template/>
 [Tinkerbell custom functions]: {{< repo_tree "tink/controller/internal/workflow/template_funcs.go" >}}
-[Hardware data contract]: {{< repo_tree "tink/controller/internal/workflow/reconciler.go#L401" >}}
 [Template Kubernetes CRD]: {{< repo_tree "crd/bases/tinkerbell.org_templates.yaml" >}}
 [Template Go struct definition]: {{< repo_tree "api/v1alpha1/tinkerbell/template.go#L36" >}}
 [Explorable Template Spec]: https://doc.crds.dev/github.com/tinkerbell/tinkerbell/tinkerbell.org/Hardware/v1alpha1@{{< tinkerbell_version >}}

--- a/content/docs/concepts/workflows.md
+++ b/content/docs/concepts/workflows.md
@@ -32,7 +32,17 @@ The `hardwareMap` field is a map of User defined key-value pairs that can be ref
 
 ## Workflow Status
 
-The status of a Workflow is updated by the [tink-controller]. Tink-controller will initially render the Template from `templateRef` interpolating any templating in the Template and then saving the whole Template into the status. As the Workflow progresses through its lifecycle, tink-controller will update fields like `seconds`, `startedAt`, and `status`. The status field can be used to determine the current state of the Workflow and to identify any issues that may have occurred during the execution of the Workflow. Get the workflow status by running `kubectl get workflow -o yaml example`. The following Workflow `status` values are possible: `STATE_PENDING`, `STATE_RUNNING`, `STATE_FAILED`, `STATE_TIMEOUT`, and `STATE_SUCCESS`.
+The status of a Workflow is updated by the [tink-controller]. Tink-controller will initially render the Template from `templateRef` interpolating any templating in the Template and then saving the whole Template into the status. As the Workflow progresses through its lifecycle, tink-controller will update fields like `seconds`, `startedAt`, and `status`. The status field can be used to determine the current state of the Workflow and to identify any issues that may have occurred during the execution of the Workflow. Get the workflow status by running `kubectl get workflow -o yaml example`. The `state` can be roughly
+separated into two groups: Execution state and final result. During the execution, a workflow goes through the following states:
+- `PREPARING`: State of a new workflow that's not yet ready for execution, e.g. because the `allowPXE` option needs to be toggled on the [Hardware] first
+- `PENDING`: A workflow ready for execution. First state of a new Workflow that does not need any further preparation
+- `RUNNING`: State of a workflow that is currently being executed on the target Hardware
+- `POST`: This state indicates that the last Action of the last Task of the Workflow was successful and the Workflow is now executing post-run actions, e.g. toggling `allowPXE` back to `False` on the [Hardware]
+
+Then there are three states a Workflow can be in once it finishes, one way or another:
+- `SUCCESS`: The Workflow was successful, all Actions in all Tasks were successful
+- `FAILED`: At least one Action, or a preparatory/post step failed
+- `TIMEOUT`: A Workflow ends up in this state when it hits the `global_timeout` set in the [Template] while still in the `RUNNING` state
 
 ## Troubleshooting
 

--- a/content/docs/concepts/workflows.md
+++ b/content/docs/concepts/workflows.md
@@ -30,16 +30,23 @@ spec:
 
 The `hardwareMap` field is a map of User defined key-value pairs that can be referenced in a [Template]. Normally, one of these key-value pairs is used to specify a worker ID in the Template. This value is normally the MAC address of the NIC (network interface card) that the worker will use to network boot. `hardwareMap` does not support nested objects.
 
-## Workflow Status
+## Workflow State
 
-The status of a Workflow is updated by the [tink-controller]. Tink-controller will initially render the Template from `templateRef` interpolating any templating in the Template and then saving the whole Template into the status. As the Workflow progresses through its lifecycle, tink-controller will update fields like `seconds`, `startedAt`, and `status`. The status field can be used to determine the current state of the Workflow and to identify any issues that may have occurred during the execution of the Workflow. Get the workflow status by running `kubectl get workflow -o yaml example`. The `state` can be roughly
-separated into two groups: Execution state and final result. During the execution, a workflow goes through the following states:
-- `PREPARING`: State of a new workflow that's not yet ready for execution, e.g. because the `allowPXE` option needs to be toggled on the [Hardware] first
-- `PENDING`: A workflow ready for execution. First state of a new Workflow that does not need any further preparation
-- `RUNNING`: State of a workflow that is currently being executed on the target Hardware
+The status of a Workflow is updated by the [tink-controller]. Tink-controller will initially render the Template from `templateRef` interpolating any templating in the Template and then saving the whole Template into the `spec.status.tasks` field. As the Workflow progresses through its lifecycle, tink-controller will update fields like `seconds`, `startedAt`, and `state`. The `spec.status.state` field can be used to determine the current state of the Workflow and to identify any issues that may have occurred during the execution of the Workflow. Get the Workflow state by running `kubectl get wf -n tinkerbell -o=jsonpath="{.status.state}" example`. The `state` can be roughly separated into two groups: Execution state and final result.
+
+### Execution States
+
+During the execution, a Workflow goes through the following states:
+
+- `PREPARING`: State of a new Workflow that's not yet ready for execution, e.g. because the `allowPXE` option needs to be toggled on the [Hardware] first
+- `PENDING`: A Workflow ready for execution. First state of a new Workflow that does not need any further preparation
+- `RUNNING`: State of a Workflow that is currently being executed on the target Hardware
 - `POST`: This state indicates that the last Action of the last Task of the Workflow was successful and the Workflow is now executing post-run actions, e.g. toggling `allowPXE` back to `False` on the [Hardware]
 
-Then there are three states a Workflow can be in once it finishes, one way or another:
+### Final States
+
+There are three terminal states in which a Workflow can be. These states have no further transitions and indicate the final result of the Workflow execution:
+
 - `SUCCESS`: The Workflow was successful, all Actions in all Tasks were successful
 - `FAILED`: At least one Action, or a preparatory/post step failed
 - `TIMEOUT`: A Workflow ends up in this state when it hits the `global_timeout` set in the [Template] while still in the `RUNNING` state

--- a/content/docs/concepts/workflows.md
+++ b/content/docs/concepts/workflows.md
@@ -3,7 +3,6 @@ title: 'Workflows'
 draft: false
 weight: 40
 geekdocDescription: 'Workflows bring together Hardware and a Template for execution.'
-latestTinkerbellVersion: "https://github.com/tinkerbell/tinkerbell/tree/v0.18.3"
 ---
 
 A Workflow brings together [Hardware] and a [Template] for execution.
@@ -50,6 +49,6 @@ If after submitting a Workflow and a `kubectl get workflow example` does not sho
 [Hardware]: /docs/concepts/hardware
 [Template]: /docs/concepts/templates
 [tink-controller]: /docs/services/tink-controller
-[Workflow Kubernetes CRD]: {{< stringparam "latestTinkerbellVersion" >}}/crd/bases/tinkerbell.org_workflows.yaml
-[Workflow Go struct definition]: {{< stringparam "latestTinkerbellVersion" >}}/api/v1alpha1/tinkerbell/workflow.go#L53
-[Explorable Workflow Spec]: <https://doc.crds.dev/github.com/tinkerbell/tinkerbell/tinkerbell.org/Workflow/v1alpha1>
+[Workflow Kubernetes CRD]: {{< repo_tree "crd/bases/tinkerbell.org_workflows.yaml" >}}
+[Workflow Go struct definition]: {{< repo_tree "api/v1alpha1/tinkerbell/workflow.go#L53" >}}
+[Explorable Workflow Spec]: https://doc.crds.dev/github.com/tinkerbell/tinkerbell/tinkerbell.org/Workflow/v1alpha1@{{< tinkerbell_version >}}

--- a/content/docs/services/rufio.md
+++ b/content/docs/services/rufio.md
@@ -2,7 +2,6 @@
 title: 'Rufio'
 draft: false
 geekdocDescription: "Kubernetes controller for BMC interactions."
-latestTinkerbellVersion: "https://github.com/tinkerbell/tinkerbell/tree/v0.18.3"
 ---
 
 ## Who is Rufio?
@@ -13,7 +12,7 @@ Besides being the leader of the Lost Boys after Peter Pan left Neverland, Rufio 
 
 ![architecture](/images/services/rufio/architecture.png)
 
-Rufio controller consists of three main API types, [Machine]({{< stringparam "latestTinkerbellVersion" >}}/api/v1alpha1/bmc/machine.go), [Job]({{< stringparam "latestTinkerbellVersion" >}}/api/v1alpha1/bmc/job.go) and [Task]({{< stringparam "latestTinkerbellVersion" >}}/api/v1alpha1/bmc/task.go). An operator or an automated client like [CAPT](https://github.com/tinkerbell/cluster-api-provider-tinkerbell) can interact with Rufio using these APIs to manage the state of their physical machines.
+Rufio controller consists of three main API types, [Machine]({{< repo_tree "api/v1alpha1/bmc/machine.go" >}}), [Job]({{< repo_tree "api/v1alpha1/bmc/job.go" >}}) and [Task]({{< repo_tree "/api/v1alpha1/bmc/task.go" >}}). An operator or an automated client like [CAPT](https://github.com/tinkerbell/cluster-api-provider-tinkerbell) can interact with Rufio using these APIs to manage the state of their physical machines.
 
 ### Machine API
 
@@ -192,13 +191,13 @@ default        job-sample-task-2      3s
 
 Options per provider can be defined in the `spec.connection.providerOptions` field of a `Machine` or `Task` object.
 
-> Note: when the `rpc` provider options are specified:  
-    1. the `authSecretRef` is not required, otherwise it is required.  
+> Note: when the `rpc` provider options are specified:
+    1. the `authSecretRef` is not required, otherwise it is required.
     2. under the hood, no other providers will be tried/used.
 
 `Machine` CR example:
 
-> Note: The provider options below are not comprehensive. See the [spec]({{< stringparam "latestTinkerbellVersion" >}}/crd/bases/bmc.tinkerbell.org_machines.yaml) for all available options.
+> Note: The provider options below are not comprehensive. See the [spec]({{< repo_tree "crd/bases/bmc.tinkerbell.org_machines.yaml" >}}) for all available options.
 
 ```yaml
 apiVersion: bmc.tinkerbell.org/v1alpha1

--- a/content/docs/services/rufio.md
+++ b/content/docs/services/rufio.md
@@ -193,7 +193,7 @@ Options per provider can be defined in the `spec.connection.providerOptions` fie
 
 > Note: when the `rpc` provider options are specified:
 >
-> 1. the `authSecretRef` is not required, otherwise it is required.
+> 1. the `authSecretRef` is not required.
 > 1. under the hood, no other providers will be tried/used.
 
 `Machine` CR example:

--- a/content/docs/services/rufio.md
+++ b/content/docs/services/rufio.md
@@ -192,8 +192,9 @@ default        job-sample-task-2      3s
 Options per provider can be defined in the `spec.connection.providerOptions` field of a `Machine` or `Task` object.
 
 > Note: when the `rpc` provider options are specified:
-    1. the `authSecretRef` is not required, otherwise it is required.
-    2. under the hood, no other providers will be tried/used.
+>
+> 1. the `authSecretRef` is not required, otherwise it is required.
+> 1. under the hood, no other providers will be tried/used.
 
 `Machine` CR example:
 

--- a/content/docs/services/smee.md
+++ b/content/docs/services/smee.md
@@ -2,7 +2,6 @@
 title: "Smee"
 draft: false
 geekdocDescription: "DHCP, iPXE, Syslog, network boot server."
-latestTinkerbellVersion: "https://github.com/tinkerbell/tinkerbell/tree/v0.18.3"
 ---
 
 ## Overview
@@ -12,7 +11,7 @@ Smee is Tinkerbell's DHCP server, handling IP addresses and requests.
 It is also the TFTP server, serving iPXE and the initial installation image.
 
 Smee is written in Go, and can be built, run, and tested outside of the Tinkerbell stack.
-Take a look at the code in the [smee/ directory]({{< stringparam "latestTinkerbellVersion" >}}/smee)
+Take a look at the code in the [smee/ directory]({{< repo_tree "smee/" >}})
 of the Tinkerbell [GitHub repository](https://github.com/tinkerbell/tinkerbell).
 
 ##### Responsibilities

--- a/content/docs/services/tink-server.md
+++ b/content/docs/services/tink-server.md
@@ -2,7 +2,6 @@
 title: "Tink Server"
 draft: false
 geekdocDescription: "A gRPC server for interacting with Tink workers."
-latestTinkerbellVersion: "https://github.com/tinkerbell/tinkerbell/tree/v0.18.3"
 ---
 
 ## Overview
@@ -18,4 +17,4 @@ Tink Server retrieves tasks from and updates task status' on [`Workflow`][workfl
 ## Other Resources
 
 [tink worker]: /docs/services/tink-worker
-[workflow]: {{< stringparam "latestTinkerbellVersion" >}}/api/v1alpha1/tinkerbell/workflow.go
+[workflow]: {{< repo_tree "api/v1alpha1/tinkerbell/workflow.go" >}}

--- a/content/docs/services/tootles.md
+++ b/content/docs/services/tootles.md
@@ -2,7 +2,6 @@
 title: "Tootles"
 draft: false
 geekdocDescription: "The metadata server for Tinkerbell."
-latestTinkerbellVersion: "https://github.com/tinkerbell/tinkerbell/tree/v0.18.3"
 ---
 
 ## Overview
@@ -10,7 +9,7 @@ latestTinkerbellVersion: "https://github.com/tinkerbell/tinkerbell/tree/v0.18.3"
 Tootles is Tinkerbell's metadata store that can be used during common provisioning processes such as cloud-init.
 Metadata is exposed over HTTP and sources from various fields on the [`Hardware`] custom resource.
 
-Take a look at the code in the [tootles directory]({{< stringparam "latestTinkerbellVersion" >}}/tootles) of the GitHub repository.
+Take a look at the code in the [tootles directory]({{< repo_tree "tootles" >}}) of the GitHub repository.
 
 ## Architecture
 

--- a/content/docs/setup/install.md
+++ b/content/docs/setup/install.md
@@ -77,33 +77,33 @@ Default configuration values can be changed using one or more `--set <parameter>
 1. Install the Tinkerbell Helm chart.
 
    ```bash
-# Get the pod CIDRs to set as trusted proxies
-TRUSTED_PROXIES=$(kubectl get nodes -o jsonpath='{.items[*].spec.podCIDR}' | tr ' ' ',')
-
-# Set the LoadBalancer IP for Tinkerbell services
-LB_IP=192.0.2.116
-
-# Set the artifacts file server URL for HookOS
-ARTIFACTS_FILE_SERVER=http://192.0.2.117:7173
-
-# Specify the Tinkerbell Helm chart version, here we use the latest release.
-TINKERBELL_CHART_VERSION={{< tinkerbell_version >}}
-
-helm install tinkerbell oci://ghcr.io/tinkerbell/charts/tinkerbell \
-  --version $TINKERBELL_CHART_VERSION \
-  --create-namespace \
-  --namespace tinkerbell \
-  --wait \
-  --set "trustedProxies={${TRUSTED_PROXIES}}" \
-  --set "publicIP=$LB_IP" \
-  --set "artifactsFileServer=$ARTIFACTS_FILE_SERVER"
+   # Get the pod CIDRs to set as trusted proxies
+   TRUSTED_PROXIES=$(kubectl get nodes -o jsonpath='{.items[*].spec.podCIDR}' | tr ' ' ',')
+   
+   # Set the LoadBalancer IP for Tinkerbell services
+   LB_IP=192.0.2.116
+   
+   # Set the artifacts file server URL for HookOS
+   ARTIFACTS_FILE_SERVER=http://192.0.2.117:7173
+   
+   # Specify the Tinkerbell Helm chart version, here we use the latest release.
+   TINKERBELL_CHART_VERSION={{< tinkerbell_version >}}
+   
+   helm install tinkerbell oci://ghcr.io/tinkerbell/charts/tinkerbell \
+     --version $TINKERBELL_CHART_VERSION \
+     --create-namespace \
+     --namespace tinkerbell \
+     --wait \
+     --set "trustedProxies={${TRUSTED_PROXIES}}" \
+     --set "publicIP=$LB_IP" \
+     --set "artifactsFileServer=$ARTIFACTS_FILE_SERVER"
    ```
 
 1. Verify the stack is up and running.
 
    ```bash
-   kubectl get pods -n tink # verify all pods are running
-   kubectl get svc -n tink # Verify the tinkerbell service has the IP you specified with $LB_IP under the EXTERNAL-IP column
+   kubectl get pods -n tinkerbell # verify all pods are running
+   kubectl get svc -n tinkerbell # Verify the tinkerbell service has the IP you specified with $LB_IP under the EXTERNAL-IP column
    ```
 
 ## Post installation steps
@@ -116,7 +116,7 @@ See the docs on [Hardware], [Templates], and [Workflows] for more information.
 Uninstall the Tinkerbell stack via Helm.
 
 ```bash
-helm uninstall tink-stack -n tink
+helm uninstall tinkerbell -n tinkerbell
 ```
 
 ## Design notes

--- a/content/docs/setup/install.md
+++ b/content/docs/setup/install.md
@@ -121,14 +121,7 @@ helm uninstall tinkerbell -n tinkerbell
 
 ## Design notes
 
-The Helm chart was designed to allow the entire stack to be hosted behind a single IP. This significantly simplifies the proper deployment of the stack.
-
-In order to achieve this the stack chart does not use a Kubernetes ingress object and controller. This is because most ingress controllers do not support UDP, TCP, HTTP, and gRPC. The ingress controllers that do support UDP are generally a bit heavy to deploy and operate and require a lot of extra configuration, custom resources, etc.
-
-To allow for this, the chart deploys a [kube-vip](https://kube-vip.io/) instance, which provides a LoadBalancer IP to the Tinkerbell service. Tinkerbell itself is a single binary listening on multiple ports for the different services making up the stack.
-To allow for DHCP broadcast traffic to reach Tinkerbell, the chart manually creates an additional network interface on the host running Tinkerbell, which receives the broadcast traffic and forwards it to the Tinkerbell Pod.
-
-In the future there is potential for moving away from this lightweight Nginx setup and using the [GatewayAPI] for traffic routing. As the Tinkerbell stack will require both UDP, TCP, and gRPC we'll need an implementation that can support all three. Currently, because of limited Maintainer cycles and the limited support for all these protocols in the existing GatewayAPI implementations, we have not pursued this path.
+To allow for DHCP broadcast traffic to reach Tinkerbell, the chart has an init container that creates an additional network interface on the host running Tinkerbell and then moves this interface into the Tinkerbell Pod. This allows Tinkerbell to receive and send broadcast traffic on the layer 2 network.
 
 [^1]: The HookOS artifacts must be named as follows: `vmlinuz-x86_64`, `initramfs-x86_64`, `vmlinuz-aarch64`, and `initramfs-aarch64`
 

--- a/hugo.toml
+++ b/hugo.toml
@@ -64,7 +64,7 @@ geekdocBackToTop = false
 geekdocRepo = "https://github.com/tinkerbell/tinkerbell.org"
 geekdocEditPath = "edit/main/"
 
-tinkerbellVersion = "v0.18.3"
+tinkerbellVersion = "v0.19.0"
 tinkerbellRepo = "https://github.com/tinkerbell/tinkerbell/"
 
 [[menu.shortcuts]]

--- a/hugo.toml
+++ b/hugo.toml
@@ -64,6 +64,9 @@ geekdocBackToTop = false
 geekdocRepo = "https://github.com/tinkerbell/tinkerbell.org"
 geekdocEditPath = "edit/main/"
 
+tinkerbellVersion = "v0.18.3"
+tinkerbellRepo = "https://github.com/tinkerbell/tinkerbell/"
+
 [[menu.shortcuts]]
 name = "<i class='fab fa-fw fa-slack'></i> <em>Slack</em>"
 url = "https://cloud-native.slack.com/archives/C01SRB41GMT"

--- a/layouts/shortcodes/repo_tree.html
+++ b/layouts/shortcodes/repo_tree.html
@@ -1,0 +1,1 @@
+{{ with .Get 0 }}{{ $.Site.Params.tinkerbellRepo }}/tree/{{ $.Site.Params.tinkerbellVersion }}/{{ . }}{{ end }}

--- a/layouts/shortcodes/tinkerbell_version.html
+++ b/layouts/shortcodes/tinkerbell_version.html
@@ -1,0 +1,1 @@
+{{ $.Site.Params.tinkerbellVersion }}


### PR DESCRIPTION
## Description

This PR is another grapbag of updates to the documentation.

### Introduction of central Tinkerbell version

There are now `params.tinkerbellVersion` and `params.tinkerbellRepo` settings in the `hugo.toml` file. These are then used in two new shortcodes.

The first one is `tinkerbell_version`. It doesn't take any parameters and just outputs the value of `params.tinkerbellVersion`.

The second is `repo_tree`. It takes the `tinkerbellRepo` and `tinkerbellVersion` plus an argument and constructs a path from those.
For example, `{{ repo_tree "README.md" }}` would result in this address: https://github.com/tinkerbell/tinkerbell/tree/v0.18.3/README.md

The idea behind these is that we don't have to touch a dozen links when we do an update.

### Updated HW data and functions usable in templates

In contrast to what the docs said, more than just the `Hardware.Disks` values could be used from the Hardware spec when writing templates.
In addition, I saw that Sprig functions could also be used.

### Updated the Install page

It still contained old names for the Helm chart and Helm chart values.

### Updated Workflow states

I've looked through the code and updated the Workflow states so they fit the code. This fixes tinkerbell/tinkerbell#209

## Why is this needed

These changes make the docs nicer and more useful.

## How Has This Been Tested?
I ran `hugo server -D` and checked visually that everything still looked okay.


## How are existing users impacted? What migration steps/scripts do we need?

No impacts on existing users.


## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)