### PR TITLE
Some small updates to the Getting Started page

### DIFF
--- a/content/docs/setup/getting_started.md
+++ b/content/docs/setup/getting_started.md
@@ -377,26 +377,39 @@ Follow these steps to create the stack on a Libvirt VM using Vagrant. Then deplo
 
    </details>
 
-1. Wait for HookOS and Ubuntu image to be downloaded
+1. Wait for Ubuntu image and HookOS to be downloaded
 
    ```bash
    vagrant ssh stack
    kubectl get jobs -n tink-system --watch
+   kubectl get pods -n tink-system --watch
    exit
-   # There are 2 Kubernetes jobs that run to download HookOS and the Ubuntu image.
-   # Once both jobs are complete exit the stack VM.
+   # There is one Kubernetes job to download the Ubuntu image and an init
+   # container in the hookos pod downloading the HookOS artifacts.
+   # Once the job is completed and the hookos pod is in running state, exit
+   # the stack VM.
    ```
 
    <details>
    <summary>example output</summary>
 
+   Ubuntu image download:
    ```bash
+   kubectl get jobs -n tink-system --watch
    NAME                    COMPLETIONS   DURATION   AGE
-   download-hook           1/1           27s        72s
    download-ubuntu-jammy   0/1           49s        49s
    download-ubuntu-jammy   0/1           70s        70s
    download-ubuntu-jammy   0/1           72s        72s
    download-ubuntu-jammy   1/1           72s        72s
+   ```
+   HookOS pod:
+   ```bash
+   kubectl get pods -n tink-system --watch
+   NAME                          READY   STATUS      RESTARTS   AGE
+   download-ubuntu-jammy-2w4wn   0/1     Completed   0          38m
+   hookos-58b848576b-hzsv4       2/2     Running     0          38m
+   kube-vip-kzr6k                1/1     Running     0          38m
+   tinkerbell-94b85bb97-tkr9q    1/1     Running     0          38m
    ```
 
    </details>
@@ -841,26 +854,39 @@ Follow these steps to create the stack on a Virtualbox VM using Vagrant. Then de
 
    </details>
 
-1. Wait for HookOS and Ubuntu image to be downloaded
+1. Wait for Ubuntu image and HookOS to be downloaded
 
    ```bash
    vagrant ssh stack
    kubectl get jobs -n tink-system --watch
+   kubectl get pods -n tink-system --watch
    exit
-   # There are 2 Kubernetes jobs that run to download HookOS and the Ubuntu image.
-   # Once both jobs are complete exit the stack VM.
+   # There is one Kubernetes job to download the Ubuntu image and an init
+   # container in the hookos pod downloading the HookOS artifacts.
+   # Once the job is completed and the hookos pod is in running state, exit
+   # the stack VM.
    ```
 
    <details>
    <summary>example output</summary>
 
+   Ubuntu image download:
    ```bash
+   kubectl get jobs -n tink-system --watch
    NAME                    COMPLETIONS   DURATION   AGE
-   download-hook           1/1           27s        72s
    download-ubuntu-jammy   0/1           49s        49s
    download-ubuntu-jammy   0/1           70s        70s
    download-ubuntu-jammy   0/1           72s        72s
    download-ubuntu-jammy   1/1           72s        72s
+   ```
+   HookOS pod:
+   ```bash
+   kubectl get pods -n tink-system --watch
+   NAME                          READY   STATUS      RESTARTS   AGE
+   download-ubuntu-jammy-2w4wn   0/1     Completed   0          38m
+   hookos-58b848576b-hzsv4       2/2     Running     0          38m
+   kube-vip-kzr6k                1/1     Running     0          38m
+   tinkerbell-94b85bb97-tkr9q    1/1     Running     0          38m
    ```
 
    </details>

--- a/content/docs/setup/getting_started.md
+++ b/content/docs/setup/getting_started.md
@@ -503,6 +503,12 @@ Follow these steps to create the stack on a Libvirt VM using Vagrant. Then deplo
    ```bash
    ssh tink@192.168.56.43 # user/pass => tink/tink
    ```
+1. Clean up
+
+   After you're done with the playground, clean up all VMs:
+   ```bash
+   vagrant destroy
+   ```
 
 ## Vagrant and VirtualBox
 
@@ -987,6 +993,13 @@ Follow these steps to create the stack on a Virtualbox VM using Vagrant. Then de
 
    ```bash
    ssh tink@192.168.56.43 # user/pass => tink/tink
+   ```
+
+1. Clean up
+
+   After you're done with the playground, clean up all VMs:
+   ```bash
+   vagrant destroy
    ```
 
 ## Get Help


### PR DESCRIPTION
## Description

I played through the Getting Started page and found two small improvements:
- The page still mentions a Kubernetes Job for downloading HookOS, but that's now done in an init container, so I removed the mention
- I also added another step for cleaning up the VMs once the reader is done with the playground, running `vagrant destroy`

## Why is this needed

No issue was raised, just a couple of small things I found.

## How Has This Been Tested?
I played through the playground instructions on a Fedora machine, and everything worked as expected.


## How are existing users impacted? What migration steps/scripts do we need?

No impact for existing users.


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
