### PR TITLE
Update Tinkerbell version to 0.19.1

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -64,7 +64,7 @@ geekdocBackToTop = false
 geekdocRepo = "https://github.com/tinkerbell/tinkerbell.org"
 geekdocEditPath = "edit/main/"
 
-tinkerbellVersion = "v0.19.0"
+tinkerbellVersion = "v0.19.1"
 tinkerbellRepo = "https://github.com/tinkerbell/tinkerbell/"
 
 [[menu.shortcuts]]


### PR DESCRIPTION
Updating the docs to the newest Tinkerbell version.

## Description

Updated the Tinkerbell version for the docs page to `0.19.1`, so it points to the newest Tinkerbell release.

## Why is this needed

Tinkerbell 0.19.1 was released yesterday.

## How Has This Been Tested?
Ran Hugo locally and checked a couple of the links which use the version as part of the URL.


## How are existing users impacted? What migration steps/scripts do we need?

No impact for existing users.

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
