### PR TITLE
Replace tink-system namespace with tinkerbell

### DIFF
--- a/content/docs/concepts/hardware.md
+++ b/content/docs/concepts/hardware.md
@@ -28,7 +28,7 @@ apiVersion: tinkerbell.org/v1alpha1
 kind: Hardware
 metadata:
   name: machine1
-  namespace: tink-system
+  namespace: tinkerbell
 spec:
   disks:
   - device: /dev/sda

--- a/content/docs/concepts/templates.md
+++ b/content/docs/concepts/templates.md
@@ -14,7 +14,7 @@ apiVersion: tinkerbell.org/v1alpha1
 kind: Template
 metadata:
   name: ubuntu
-  namespace: tink-system
+  namespace: tinkerbell
 spec:
   data: ""
 ```
@@ -163,7 +163,7 @@ apiVersion: tinkerbell.org/v1alpha1
 kind: Template
 metadata:
   name: ubuntu
-  namespace: tink-system
+  namespace: tinkerbell
 spec:
   data: |
     name: ubuntu
@@ -249,7 +249,7 @@ apiVersion: tinkerbell.org/v1alpha1
 kind: Template
 metadata:
   name: ubuntu
-  namespace: tink-system
+  namespace: tinkerbell
 spec:
   data: |
     name: ubuntu
@@ -275,7 +275,7 @@ apiVersion: tinkerbell.org/v1alpha1
 kind: Workflow
 metadata:
   name: ubuntu-install
-  namespace: tink-system
+  namespace: tinkerbell
 spec:
   templateRef: ubuntu
   hardwareRef: hardware-1

--- a/content/docs/integrations/cloudinit.md
+++ b/content/docs/integrations/cloudinit.md
@@ -62,7 +62,7 @@ apiVersion: tinkerbell.org/v1alpha1
 kind: Hardware
 metadata:
   name: example
-  namespace: tink-system
+  namespace: tinkerbell
 spec:
   userData: >-
     #cloud-config

--- a/content/docs/setup/getting_started.md
+++ b/content/docs/setup/getting_started.md
@@ -381,8 +381,8 @@ Follow these steps to create the stack on a Libvirt VM using Vagrant. Then deplo
 
    ```bash
    vagrant ssh stack
-   kubectl get jobs -n tink-system --watch
-   kubectl get pods -n tink-system --watch
+   kubectl get jobs -n tinkerbell --watch
+   kubectl get pods -n tinkerbell --watch
    exit
    # There is one Kubernetes job to download the Ubuntu image and an init
    # container in the hookos pod downloading the HookOS artifacts.
@@ -395,7 +395,7 @@ Follow these steps to create the stack on a Libvirt VM using Vagrant. Then deplo
 
    Ubuntu image download:
    ```bash
-   kubectl get jobs -n tink-system --watch
+   kubectl get jobs -n tinkerbell --watch
    NAME                    COMPLETIONS   DURATION   AGE
    download-ubuntu-jammy   0/1           49s        49s
    download-ubuntu-jammy   0/1           70s        70s
@@ -404,7 +404,7 @@ Follow these steps to create the stack on a Libvirt VM using Vagrant. Then deplo
    ```
    HookOS pod:
    ```bash
-   kubectl get pods -n tink-system --watch
+   kubectl get pods -n tinkerbell --watch
    NAME                          READY   STATUS      RESTARTS   AGE
    download-ubuntu-jammy-2w4wn   0/1     Completed   0          38m
    hookos-58b848576b-hzsv4       2/2     Running     0          38m
@@ -468,7 +468,7 @@ Follow these steps to create the stack on a Libvirt VM using Vagrant. Then deplo
 
    # watch for the workflow to complete
    # once the workflow is complete (see the expected output below for completion), move on to the next step
-   kubectl get -n tink-system workflow playground-workflow --watch
+   kubectl get -n tinkerbell workflow playground-workflow --watch
    ```
 
    <details>
@@ -864,8 +864,8 @@ Follow these steps to create the stack on a Virtualbox VM using Vagrant. Then de
 
    ```bash
    vagrant ssh stack
-   kubectl get jobs -n tink-system --watch
-   kubectl get pods -n tink-system --watch
+   kubectl get jobs -n tinkerbell --watch
+   kubectl get pods -n tinkerbell --watch
    exit
    # There is one Kubernetes job to download the Ubuntu image and an init
    # container in the hookos pod downloading the HookOS artifacts.
@@ -878,7 +878,7 @@ Follow these steps to create the stack on a Virtualbox VM using Vagrant. Then de
 
    Ubuntu image download:
    ```bash
-   kubectl get jobs -n tink-system --watch
+   kubectl get jobs -n tinkerbell --watch
    NAME                    COMPLETIONS   DURATION   AGE
    download-ubuntu-jammy   0/1           49s        49s
    download-ubuntu-jammy   0/1           70s        70s
@@ -887,7 +887,7 @@ Follow these steps to create the stack on a Virtualbox VM using Vagrant. Then de
    ```
    HookOS pod:
    ```bash
-   kubectl get pods -n tink-system --watch
+   kubectl get pods -n tinkerbell --watch
    NAME                          READY   STATUS      RESTARTS   AGE
    download-ubuntu-jammy-2w4wn   0/1     Completed   0          38m
    hookos-58b848576b-hzsv4       2/2     Running     0          38m
@@ -959,7 +959,7 @@ Follow these steps to create the stack on a Virtualbox VM using Vagrant. Then de
 
    # watch for the workflow to complete
    # once the workflow is complete (see the example output below for completion), move on to the next step
-   kubectl get -n tink-system workflow sandbox-workflow --watch
+   kubectl get -n tinkerbell workflow sandbox-workflow --watch
    ```
 
    <details>


### PR DESCRIPTION
## Description

As `tinkerbell` is now the namespace used in the Install page examples, this PR replaces all occurrences of the old `tink-system` namespace.

## Why is this needed

Just making sure all of the documentation uses a consistent namespace.

## How Has This Been Tested?
No testing has been conducted.

## How are existing users impacted? What migration steps/scripts do we need?

No impact on existing users.

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
