### PR TITLE
Some doc improvements for the Tink Server/Controller/Worker pages

### DIFF
--- a/content/docs/services/tink-controller.md
+++ b/content/docs/services/tink-controller.md
@@ -4,12 +4,15 @@ draft: false
 geekdocDescription: "Kubernetes controller for managing workflows."
 ---
 
-## Overview
+Tink Controller is a Kubernetes controller for managing [Workflows](/docs/concepts/workflows).
+It continuosly reconciles Workflows, checking for timeouts being reached as well
+as new Workflows appearing.
 
-Tink Controller is a Kubernetes controller for managing workflows.
+For new Workflows, the Controller instantiates the referenced Template for the
+referenced Hardware and puts the result in the Status of the Workflow.
 
-## Architecture
+The Controller also executes pre- and post-execution steps for Workflows, for
+example setting the Hardware's netboot status or executing BMC actions.
 
-## Usage
-
-## Other Resources
+The source code for the Controller can be found in the Tinkerbell repository
+under the [`tink/controller/`]({{< repo_tree "tink/controller" >}}) directory.

--- a/content/docs/services/tink-server.md
+++ b/content/docs/services/tink-server.md
@@ -4,17 +4,9 @@ draft: false
 geekdocDescription: "A gRPC server for interacting with Tink workers."
 ---
 
-## Overview
+Tink Server exposes workflow actions over a gRPC API for [Tink Worker] to retrieve and execute on a machine being provisioned. When a Tink worker completes an action, it reports the status back to the Tink Server and retrieves the next action, if any.
+The Tink Server uses the [Workflow]({{< repo_tree "crd/bases/tinkerbell.org_workflows.yaml" >}}) Kubernetes resource, continuously updating the Status based on the Worker's reports.
 
-Tink Server exposes workflow actions over a gRPC API for [Tink Worker] to retrieve and execute. When a [Tink Worker] completes an action, it reports the status to Tink Server.
-Tink Server uses Kubernetes custom resources to store workflow state.
-Tink Server retrieves tasks from and updates task status' on [`Workflow`][workflow] Kubernetes custom resources. Tinkerbell users submit the [`Workflow`][workflow]s to the cluster via the Kube API Server.
-
-## Architecture
-
-## Usage
-
-## Other Resources
+The Tink Server <-> Worker communication protocol is implemented with [Protobuf](https://protobuf.dev/). The proto files can be found [here]({{< repo_tree "pkg/proto" >}}).
 
 [tink worker]: /docs/services/tink-worker
-[workflow]: {{< repo_tree "api/v1alpha1/tinkerbell/workflow.go" >}}

--- a/content/docs/services/tink-worker.md
+++ b/content/docs/services/tink-worker.md
@@ -7,19 +7,13 @@ geekdocDescription: "An agent that is responsible for executing and reporting on
 ## Overview
 
 Tink Worker is an agent that runs in the operating system installation environment.
-It is responsible for retrieving workflow actions from [Tink Server] and executing them.
+It is responsible for retrieving [Workflow Actions](/docs/concepts/templates/#action) from [Tink Server] and executing them.
 Actions are published as Docker containers with Tink Worker acting as their launcher.
 When an action finishes, Tink Worker reports the status to [Tink Server]
 
 ### How Tink Worker starts
 
 In [Hook], Tinkerbell's default operating system installation environment, Tink Worker is launched by a multi-staged process. A small program called [hook-bootkit] is launched as a serivce, reads the Kernel command line for Tink Worker specific parameters, then launches Tink Worker as a Docker container. See the [LinuxKit configuration file][hook-bootkit-service] and [documentation][linuxkit] for how [hook-bootkit] is launched.
-
-## Architecture
-
-## Usage
-
-## Other Resources
 
 [hook]: /docs/additionalcomponents/hookOS
 [tink server]: /docs/services/tink-server


### PR DESCRIPTION
## Description

This small set of changes fixes a few small issues on the Tink Server, Controller and Worker pages and removes all of the empty sections.
## Why is this needed

General documentation cleanup.

## How Has This Been Tested?
I ran a local Hugo server and checked the changed pages.

## How are existing users impacted? What migration steps/scripts do we need?

No impact for existing users.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
